### PR TITLE
Fix Angular build issues: onboarding imports, Sass paths, and Discover subscriptions

### DIFF
--- a/angular-frontend/src/app/features/discover/discover.component.ts
+++ b/angular-frontend/src/app/features/discover/discover.component.ts
@@ -12,6 +12,7 @@ import { MatSliderModule } from '@angular/material/slider';
 import { FormsModule } from '@angular/forms';
 import { trigger, state, style, animate, transition } from '@angular/animations';
 import { Router } from '@angular/router';
+import { Subscription } from 'rxjs';
 import { SoulConnectionService } from '@core/services/soul-connection.service';
 import { AuthService } from '@core/services/auth.service';
 import { ErrorLoggingService } from '@core/services/error-logging.service';
@@ -505,6 +506,8 @@ export class DiscoverComponent implements OnInit, OnDestroy {
   hoveredCards = new Set<number>();
   lastAction: { type: 'pass' | 'connect' | 'super_like'; item: DiscoveryResponse; index: number; message: string; timeoutId: any } | null = null;
 
+  private subscriptions = new Subscription();
+
   discoveryFilters: DiscoveryRequest = {
     max_results: 10,
     min_compatibility: 50,
@@ -527,7 +530,7 @@ export class DiscoverComponent implements OnInit, OnDestroy {
     this.initializeABTesting();
 
     // Check authentication and onboarding status
-    this.authService.currentUser$.subscribe(user => {
+    this.subscriptions.add(this.authService.currentUser$.subscribe(user => {
       this.currentUser = user;
 
       if (!user) {
@@ -541,7 +544,11 @@ export class DiscoverComponent implements OnInit, OnDestroy {
       if (!this.needsOnboarding) {
         this.loadDiscoveries();
       }
-    });
+    }));
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions.unsubscribe();
   }
 
   loadDiscoveries(): void {
@@ -1406,6 +1413,21 @@ export class DiscoverComponent implements OnInit, OnDestroy {
    */
   private getPartnerName(discovery: DiscoveryResponse): string {
     return discovery.profile_preview?.first_name || 'soul connection';
+  }
+
+  /**
+   * Initialize A/B testing for discovery page
+   */
+  private initializeABTesting(): void {
+    const variantConfig = this.abTestingService.getVariantConfig('discovery_card_layout');
+
+    if (variantConfig) {
+      this.abTestingService.trackEvent('discovery_card_layout', 'discovery_view', {
+        layout: variantConfig.layout,
+        showCompatibilityFirst: variantConfig.showCompatibilityFirst,
+        buttonStyle: variantConfig.buttonStyle
+      });
+    }
   }
 
   /**

--- a/angular-frontend/src/app/shared/components/onboarding-manager/onboarding-manager.component.ts
+++ b/angular-frontend/src/app/shared/components/onboarding-manager/onboarding-manager.component.ts
@@ -1,9 +1,9 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Subscription } from 'rxjs';
-import { environment } from '../../../environments/environment';
-import { OnboardingService, OnboardingState } from '../../core/services/onboarding.service';
-import { AuthService } from '../../core/services/auth.service';
+import { environment } from '../../../../environments/environment';
+import { OnboardingService, OnboardingState, OnboardingStep } from '../../../core/services/onboarding.service';
+import { AuthService } from '../../../core/services/auth.service';
 import { OnboardingTooltipComponent } from '../onboarding-tooltip/onboarding-tooltip.component';
 import { OnboardingWelcomeComponent } from '../onboarding-welcome/onboarding-welcome.component';
 
@@ -412,7 +412,7 @@ export class OnboardingManagerComponent implements OnInit, OnDestroy {
 
     // Subscribe to onboarding state changes
     this.subscription.add(
-      this.onboardingService.state$.subscribe(state => {
+      this.onboardingService.state$.subscribe((state: OnboardingState) => {
         this.currentState = state;
         this.updateVisibility(state);
       })
@@ -420,7 +420,7 @@ export class OnboardingManagerComponent implements OnInit, OnDestroy {
 
     // Subscribe to active step changes
     this.subscription.add(
-      this.onboardingService.activeStep$.subscribe(step => {
+      this.onboardingService.activeStep$.subscribe((step: OnboardingStep | null) => {
         this.showTooltip = !!step;
       })
     );

--- a/angular-frontend/src/styles.scss
+++ b/angular-frontend/src/styles.scss
@@ -1,8 +1,8 @@
 /* Import WCAG 2.1 AA Compliant Color System */
-@import 'app/shared/styles/accessibility-colors';
+@import './app/shared/styles/accessibility-colors.scss';
 
 /* Import Swipe Gesture Styles */
-@import 'app/shared/styles/swipe-gestures';
+@import './app/shared/styles/swipe-gestures.scss';
 
 /* Import Angular Material themes */
 @import '@angular/material/prebuilt-themes/pink-bluegrey.css';


### PR DESCRIPTION
### Motivation
- Resolve TypeScript/Angular build errors caused by incorrect import paths and missing typings in the onboarding manager.
- Prevent memory leaks and ensure proper lifecycle handling in the Discover component by managing subscriptions.
- Fix ambiguous global Sass imports that can break style resolution during build.

### Description
- Corrected relative imports in `OnboardingManagerComponent` to use the proper paths and added the `OnboardingStep` type from `onboarding.service` and typed `state`/`step` subscriptions with `OnboardingState` and `OnboardingStep` respectively.
- Disambiguated global Sass imports in `src/styles.scss` to explicit `./app/shared/styles/*.scss` paths.
- In `DiscoverComponent` added a `Subscription` container (`this.subscriptions`), wrapped `authService.currentUser$` with `this.subscriptions.add(...)`, implemented `ngOnDestroy()` to `unsubscribe()`, and added `initializeABTesting()` to call `abTestingService.getVariantConfig()` and emit an initial `trackEvent`.

### Testing
- No automated tests were executed as part of this change.
- A local TypeScript/Angular edit and commit cycle was completed and files were updated without running CI tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695773563038832796fb6fe96023911a)