### PR TITLE
feat: Docker-only dev stack + UI/UX polish (emoji → Material Icons)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -368,123 +368,89 @@ interface/Angular/src/app/
 
 ## Essential Development Commands
 
-### Backend (Python FastAPI)
+### Start / Stop (Docker — required)
 ```bash
-cd backend_py
-source venv/bin/activate  # Create venv first time: python -m venv venv
-pip install -r requirements.txt
-python run.py  # Runs on port 5000
-pytest  # Run tests
-alembic upgrade head  # Apply migrations
-alembic revision --autogenerate -m "Add soul before skin tables"  # Create migrations
+# Start everything (PostgreSQL + backend + frontend)
+./start-app.sh          # or: docker compose -f docker-compose.dev.yml up --build
+
+# Stop all services
+./start-app.sh down     # or: docker compose -f docker-compose.dev.yml down
+
+# Tail logs
+./start-app.sh logs             # all services
+./start-app.sh logs backend     # backend only
+./start-app.sh logs frontend    # frontend only
+
+# Wipe database and restart fresh
+./start-app.sh reset
 ```
 
-### Angular Frontend
+### Backend (inside container)
 ```bash
-cd interface/Angular
-npm install
-ng serve --port 5001  # Must use port 5001 for CORS
-ng test
-ng build
-npm run serve:ssr:dinner-app  # SSR build
-ng generate component features/onboarding/emotional-questions  # Generate components
-ng generate service core/services/soul-connection  # Generate services
+# Run tests
+docker compose -f docker-compose.dev.yml exec backend pytest
+
+# Create a new migration
+docker compose -f docker-compose.dev.yml exec backend \
+  alembic revision --autogenerate -m "description"
+
+# Apply migrations manually (runs automatically on startup)
+docker compose -f docker-compose.dev.yml exec backend alembic upgrade head
+
+# Open a shell
+docker compose -f docker-compose.dev.yml exec backend sh
+```
+
+### Angular Frontend (inside container)
+```bash
+# Generate a component
+docker compose -f docker-compose.dev.yml exec frontend \
+  npx ng generate component features/onboarding/emotional-questions
+
+# Generate a service
+docker compose -f docker-compose.dev.yml exec frontend \
+  npx ng generate service core/services/soul-connection
+
+# Run unit tests (runs on host, not in container)
+cd angular-frontend && npx ng test --watch=false --browsers=ChromeHeadless
 ```
 
 ## Environment Setup
 
-### Required Backend Environment (.env in backend_py/)
-```
-DATABASE_URL=postgresql://postgres:postgres@localhost:5432/dinner_first
-SECRET_KEY=your_jwt_secret_here
-CORS_ORIGINS=http://localhost:4200,http://localhost:5001
+All environment variables are defined in `docker-compose.dev.yml`.
+No `.env` file is required for local development — defaults are pre-configured.
 
-# Soul Before Skin specific
-COMPATIBILITY_THRESHOLD=50
-REVELATION_CYCLE_DAYS=7
-EMOTIONAL_DEPTH_WEIGHT=0.3
-```
-
-### Angular Environment (Enhanced)
-Update `interface/Angular/src/environments/environment.ts`:
-```typescript
-export const environment = {
-  production: false,
-  apiUrl: 'http://localhost:5000/api/v1',  // Must include /api/v1
-
-  // Soul Before Skin configuration
-  soulBeforeSkin: {
-    revelationCycleDays: 7,
-    compatibilityThreshold: 50,
-    defaultPhotoHidden: true,
-    emotionalOnboardingRequired: true
-  }
-};
-```
-
-## Local Development Environment
-
-### Development Setup (No Online Dependencies)
-**Complete Offline Development**:
-- Angular CLI with local development server
-- FastAPI with local algorithm processing
-- PostgreSQL running locally
-- No external APIs or cloud services required
-- All matching algorithms run locally in milliseconds
-
-**Database Setup**:
-```bash
-# Local PostgreSQL setup
-brew install postgresql  # macOS
-sudo apt-get install postgresql  # Ubuntu
-docker run --name postgres-local -e POSTGRES_PASSWORD=postgres -p 5432:5432 -d postgres  # Docker
-
-# Database initialization
-createdb dinner_first
-psql dinner_first < schema.sql
-```
+For production, copy `python-backend/.env.example` to `python-backend/.env` and fill in secrets.
 
 ## Development Workflow
 
-1. **Start PostgreSQL** (required for backend)
-   ```bash
-   brew services start postgresql  # macOS
-   sudo service postgresql start  # Ubuntu
-   ```
+1. **Ensure Docker Desktop is running**
 
-2. **Backend Development**:
+2. **Start the full stack**:
    ```bash
-   cd backend_py
-   source venv/bin/activate
-   python run.py  # Runs on port 5000
+   ./start-app.sh
    ```
+   On first run this builds images and runs `alembic upgrade head` automatically.
 
-3. **Angular Frontend**:
+3. **Test connectivity**:
    ```bash
-   cd interface/Angular
-   ng serve --port 5001  # Must use port 5001
-   ```
-
-4. **Test Connectivity**:
-   ```bash
-   python test_connection.py
-   curl http://localhost:5000/health
+   curl http://localhost:8000/health
    ```
 
 ## Key Access Points
-- **Backend API**: http://localhost:5000
-- **API Documentation**: http://localhost:5000/docs
-- **Angular Frontend**: http://localhost:5001
-- **Health Check**: http://localhost:5000/health
-- **Soul Connection Discovery**: http://localhost:5001/discover
-- **Emotional Onboarding**: http://localhost:5001/onboarding
+- **Backend API**: http://localhost:8000
+- **API Documentation**: http://localhost:8000/docs
+- **Angular Frontend**: http://localhost:4200
+- **Health Check**: http://localhost:8000/health
+- **Soul Connection Discovery**: http://localhost:4200/discover
+- **Emotional Onboarding**: http://localhost:4200/onboarding
 
 ## Critical Requirements
-- **PostgreSQL** must be running on port 5432
-- **Backend** runs on port 5000 with enhanced soul connection endpoints
-- **Angular** must use port 5001 for proper CORS configuration
-- **Database migrations** must be applied with `alembic upgrade head`
-- **Local algorithms** only - no external API dependencies
+- **Docker Desktop** must be running — no local PostgreSQL, Python, or Node.js required
+- **Backend** runs on port 8000 (FastAPI + uvicorn with hot-reload)
+- **Frontend** runs on port 4200 (Angular `ng serve`)
+- **Database migrations** run automatically on backend container startup
+- **Local algorithms** only — no external API dependencies
 - **Emotional onboarding** required before accessing matching features
 
 ## MVP Validation Metrics

--- a/angular-frontend/Dockerfile.dev
+++ b/angular-frontend/Dockerfile.dev
@@ -1,0 +1,10 @@
+FROM node:18-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+EXPOSE 4200
+
+CMD ["npx", "ng", "serve", "--host", "0.0.0.0", "--port", "4200", "--poll=2000", "--disable-host-check"]

--- a/angular-frontend/angular.json
+++ b/angular-frontend/angular.json
@@ -34,7 +34,6 @@
               "src/assets"
             ],
             "styles": [
-              "@angular/material/prebuilt-themes/rose-red.css",
               "src/styles.scss"
             ],
             "scripts": []
@@ -98,7 +97,6 @@
               "src/assets"
             ],
             "styles": [
-              "@angular/material/prebuilt-themes/rose-red.css",
               "src/styles.scss"
             ],
             "scripts": [],

--- a/angular-frontend/src/app/core/services/message.service.spec.ts
+++ b/angular-frontend/src/app/core/services/message.service.spec.ts
@@ -238,7 +238,7 @@ describe('MessageService', () => {
 
     it('should handle special characters in message text', () => {
       const connectionId = 333;
-      const messageText = 'Hello 👋 \n\t "quotes" \'apostrophes\'';
+      const messageText = 'Hello \n\t "quotes" \'apostrophes\'';
 
       service.sendMessage(connectionId, messageText).subscribe();
 
@@ -437,7 +437,7 @@ describe('MessageService', () => {
 
     it('should handle special characters in new text', () => {
       const messageId = 789;
-      const newText = 'Updated 🎉 with "quotes" and \n newlines';
+      const newText = 'Updated with "quotes" and \n newlines';
 
       service.editMessage(messageId, newText).subscribe();
 

--- a/angular-frontend/src/app/core/services/notification.service.ts
+++ b/angular-frontend/src/app/core/services/notification.service.ts
@@ -149,19 +149,19 @@ export class NotificationService {
     const notificationTypes = [
       {
         type: 'message' as const,
-        title: 'New Message 💬',
+        title: 'New Message',
         message: 'You received a heartfelt message',
         actionUrl: '/messages'
       },
       {
         type: 'revelation' as const,
-        title: 'New Revelation! ✨',
+        title: 'New Revelation',
         message: 'Someone shared a meaningful revelation with you',
         actionUrl: '/revelations?connectionId=1'
       },
       {
         type: 'match' as const,
-        title: 'New Match! 💫',
+        title: 'New Match',
         message: 'You have a high compatibility match waiting',
         actionUrl: '/matches'
       }

--- a/angular-frontend/src/app/core/services/onboarding-api.service.spec.ts
+++ b/angular-frontend/src/app/core/services/onboarding-api.service.spec.ts
@@ -471,7 +471,7 @@ describe('OnboardingApiService', () => {
     });
 
     it('should handle special characters in responses', () => {
-      const specialText = 'Test with "quotes", \'apostrophes\', \n newlines, and émojis 🎉';
+      const specialText = 'Test with "quotes", \'apostrophes\', \n newlines, and special chars';
       const mockData: OnboardingData = {
         relationship_values: specialText,
         ideal_evening: specialText,

--- a/angular-frontend/src/app/core/services/onboarding.service.ts
+++ b/angular-frontend/src/app/core/services/onboarding.service.ts
@@ -81,7 +81,7 @@ export class OnboardingService {
       steps: [
         {
           id: 'welcome',
-          title: '✨ Welcome to Dinner First',
+          title: 'Welcome to Dinner First',
           description: 'Where souls connect before eyes meet. Let us show you how meaningful connections begin with emotional compatibility.',
           position: 'center',
           showOverlay: true,
@@ -93,7 +93,7 @@ export class OnboardingService {
         },
         {
           id: 'soul-profile',
-          title: '💖 Your Soul Profile',
+          title: 'Your Soul Profile',
           description: 'Share your values, dreams, and what makes you truly you. This creates the foundation for authentic connections.',
           targetSelector: '.profile-section',
           position: 'right',
@@ -106,7 +106,7 @@ export class OnboardingService {
         },
         {
           id: 'compatibility-magic',
-          title: '🌟 Compatibility Magic',
+          title: 'Compatibility Magic',
           description: 'Our algorithm analyzes emotional compatibility, shared values, and communication styles to find your perfect matches.',
           targetSelector: '.compatibility-score',
           position: 'top',
@@ -119,7 +119,7 @@ export class OnboardingService {
         },
         {
           id: 'soul-connections',
-          title: '💫 Soul Connections',
+          title: 'Soul Connections',
           description: 'Discover people who align with your values and dreams. Photos are revealed after you connect emotionally.',
           targetSelector: '.soul-card',
           position: 'bottom',
@@ -132,7 +132,7 @@ export class OnboardingService {
         },
         {
           id: 'meaningful-conversations',
-          title: '💬 Meaningful Conversations',
+          title: 'Meaningful Conversations',
           description: 'Start conversations about what truly matters. Share your thoughts, dreams, and build genuine connections.',
           targetSelector: '.message-area',
           position: 'left',
@@ -155,7 +155,7 @@ export class OnboardingService {
       steps: [
         {
           id: 'discovery-filters',
-          title: '🎛️ Discovery Filters',
+          title: 'Discovery Filters',
           description: 'Customize your search by compatibility threshold, age range, and photo preferences.',
           targetSelector: '.discovery-filters',
           position: 'bottom',
@@ -168,7 +168,7 @@ export class OnboardingService {
         },
         {
           id: 'soul-orb-guide',
-          title: '🔮 Soul Orb Energy',
+          title: 'Soul Orb Energy',
           description: 'The soul orb shows emotional energy and compatibility. Watch it pulse and glow for high-compatibility matches!',
           targetSelector: '.soul-orb',
           position: 'right',
@@ -181,7 +181,7 @@ export class OnboardingService {
         },
         {
           id: 'compatibility-breakdown',
-          title: '📊 Compatibility Insights',
+          title: 'Compatibility Insights',
           description: 'See detailed compatibility in values, interests, and communication style. High scores unlock special animations!',
           targetSelector: '.compatibility-score',
           position: 'top',
@@ -194,7 +194,7 @@ export class OnboardingService {
         },
         {
           id: 'keyboard-navigation',
-          title: '⌨️ Keyboard Magic',
+          title: 'Keyboard Magic',
           description: 'Use arrow keys to navigate cards, Enter to connect, and discover keyboard shortcuts for efficient browsing.',
           targetSelector: '.keyboard-help',
           position: 'top',
@@ -217,7 +217,7 @@ export class OnboardingService {
       steps: [
         {
           id: 'conversation-starters',
-          title: '💭 Soul Conversation Starters',
+          title: 'Soul Conversation Starters',
           description: 'Use our curated conversation starters to dive deep into meaningful topics that reveal true compatibility.',
           targetSelector: '.conversation-starters',
           position: 'right',
@@ -230,7 +230,7 @@ export class OnboardingService {
         },
         {
           id: 'emotional-reactions',
-          title: '💫 Emotional Reactions',
+          title: 'Emotional Reactions',
           description: 'React with emotional depth using our soul-centered emoji system. Express how messages truly make you feel.',
           targetSelector: '.message-reactions',
           position: 'top',
@@ -243,7 +243,7 @@ export class OnboardingService {
         },
         {
           id: 'revelation-sharing',
-          title: '🌅 Daily Revelations',
+          title: 'Daily Revelations',
           description: 'Share personal insights and growth moments. This deeper sharing builds authentic emotional bonds.',
           targetSelector: '.revelation-area',
           position: 'bottom',

--- a/angular-frontend/src/app/core/services/profile.service.spec.ts
+++ b/angular-frontend/src/app/core/services/profile.service.spec.ts
@@ -565,7 +565,7 @@ describe('ProfileService', () => {
       const updateData: ProfileUpdateData = {
         first_name: 'José',
         last_name: "O'Brien",
-        bio: 'Test with émojis 🎉 and "quotes"'
+        bio: 'Test with special chars and "quotes"'
       };
 
       service.updateProfile(updateData).subscribe();

--- a/angular-frontend/src/app/core/services/revelation.service.spec.ts
+++ b/angular-frontend/src/app/core/services/revelation.service.spec.ts
@@ -149,7 +149,7 @@ describe('RevelationService', () => {
   describe('Revelation Reactions', () => {
     it('should react to a revelation', () => {
       const revelationId = 1;
-      const emoji = '❤️';
+      const emoji = 'heart';
 
       const mockResponse = {
         revelation_id: revelationId,
@@ -158,7 +158,7 @@ describe('RevelationService', () => {
       };
 
       service.reactToRevelation(revelationId, emoji).subscribe(response => {
-        expect(response['emoji']).toBe('❤️');
+        expect(response['emoji']).toBe('heart');
       });
 
       const req = httpMock.expectOne(`${mockApiUrl}/revelations/${revelationId}/react`);

--- a/angular-frontend/src/app/core/services/revelation.service.ts
+++ b/angular-frontend/src/app/core/services/revelation.service.ts
@@ -114,15 +114,15 @@ export class RevelationService {
    */
   getRevelationTypeIcon(type: RevelationType): string {
     const typeIcons: Record<RevelationType, string> = {
-      personal_value: '💎',
-      meaningful_experience: '🌟',
-      hope_or_dream: '✨',
-      what_makes_laugh: '😊',
-      challenge_overcome: '💪',
-      ideal_connection: '💝',
-      photo_reveal: '📸'
+      personal_value: 'diamond',
+      meaningful_experience: 'star',
+      hope_or_dream: 'auto_awesome',
+      what_makes_laugh: 'sentiment_satisfied',
+      challenge_overcome: 'fitness_center',
+      ideal_connection: 'favorite',
+      photo_reveal: 'photo_camera'
     };
-    return typeIcons[type] || '💭';
+    return typeIcons[type] || 'chat_bubble';
   }
 
   /**

--- a/angular-frontend/src/app/core/services/storage.service.spec.ts
+++ b/angular-frontend/src/app/core/services/storage.service.spec.ts
@@ -391,7 +391,7 @@ describe('StorageService', () => {
       it('should handle Unicode characters', () => {
         localStorageSpy.setItem.and.returnValue(undefined);
 
-        const unicode = '你好 🌟 مرحبا';
+        const unicode = '你好 مرحبا';
         const result = service.setItem('unicode-key', unicode);
 
         expect(result).toBe(true);

--- a/angular-frontend/src/app/features/discover/discover-empty-state.component.ts
+++ b/angular-frontend/src/app/features/discover/discover-empty-state.component.ts
@@ -41,31 +41,31 @@ export class DiscoverEmptyStateComponent {
 
   discoveryTips = [
     {
-      icon: "✨",
+      icon: "auto_awesome",
       text: "Complete your emotional profile to help us find deeper connections"
     },
     {
-      icon: "💫",
+      icon: "stars",
       text: "Share your authentic interests and values for better matches"
     },
     {
-      icon: "🌟",
+      icon: "star",
       text: "Be patient - meaningful soul connections are worth the wait"
     },
     {
-      icon: "💖",
+      icon: "favorite",
       text: "Quality over quantity: we prioritize compatible souls over endless options"
     }
   ];
 
   primaryAction = {
     text: "Search for Soul Matches",
-    icon: "🔍"
+    icon: "search"
   };
 
   secondaryAction = {
     text: "Enhance Your Profile",
-    icon: "✨"
+    icon: "auto_awesome"
   };
 
   onRefreshMatches() {

--- a/angular-frontend/src/app/features/discover/discover.component.scss
+++ b/angular-frontend/src/app/features/discover/discover.component.scss
@@ -884,12 +884,13 @@ mat-card-actions {
   border-left: 4px solid #ef4444 !important;
 
   &::before {
-    content: '✕';
+    content: 'close';
+    font-family: 'Material Icons';
     position: absolute;
     top: 50%;
     left: 20px;
     transform: translateY(-50%);
-    font-size: 2rem;
+    font-size: 32px;
     color: #ef4444;
     font-weight: bold;
     z-index: 5;
@@ -909,12 +910,13 @@ mat-card-actions {
   border-right: 4px solid #22c55e !important;
 
   &::before {
-    content: '♡';
+    content: 'favorite';
+    font-family: 'Material Icons';
     position: absolute;
     top: 50%;
     right: 20px;
     transform: translateY(-50%);
-    font-size: 2rem;
+    font-size: 32px;
     color: #22c55e;
     font-weight: bold;
     z-index: 5;
@@ -934,12 +936,13 @@ mat-card-actions {
   border-top: 4px solid #f59e0b !important;
 
   &::before {
-    content: '⭐';
+    content: 'star';
+    font-family: 'Material Icons';
     position: absolute;
     top: 20px;
     left: 50%;
     transform: translateX(-50%);
-    font-size: 2rem;
+    font-size: 32px;
     color: #f59e0b;
     font-weight: bold;
     z-index: 5;
@@ -1060,12 +1063,14 @@ mat-card-actions {
 @media (max-width: 768px) {
   .soul-card.high-compatibility {
     &.swipe-right-preview::before {
-      content: '💖';
+      content: 'favorite';
+      font-family: 'Material Icons';
       animation: swipeIconPulse 0.3s ease-out, heartGlow 1s ease-in-out infinite alternate;
     }
 
     &.swipe-up-preview::before {
-      content: '✨';
+      content: 'star';
+      font-family: 'Material Icons';
       animation: swipeIconPulse 0.3s ease-out, starGlow 1s ease-in-out infinite alternate;
     }
   }

--- a/angular-frontend/src/app/features/discover/discover.component.ts
+++ b/angular-frontend/src/app/features/discover/discover.component.ts
@@ -1137,7 +1137,7 @@ export class DiscoverComponent implements OnInit, OnDestroy {
 
     for (let i = 0; i < heartsCount; i++) {
       const heart = document.createElement('div');
-      heart.innerHTML = '💖';
+      heart.textContent = '\u2665';
       heart.style.position = 'absolute';
       heart.style.fontSize = '1.5rem';
       heart.style.pointerEvents = 'none';
@@ -1164,7 +1164,7 @@ export class DiscoverComponent implements OnInit, OnDestroy {
    */
   private triggerConnectionSuccessEffects(discovery: DiscoveryResponse): void {
     // Create success announcement with sound for screen readers
-    this.announceAction(`🎉 Soul connection established with ${discovery.profile_preview.first_name}! Compatibility: ${discovery.compatibility.total_compatibility}%`);
+    this.announceAction(`Soul connection established with ${discovery.profile_preview.first_name}! Compatibility: ${discovery.compatibility.total_compatibility}%`);
 
     // Create page-wide celebration effect
     const celebrationOverlay = document.createElement('div');

--- a/angular-frontend/src/app/features/examples/phase3-showcase.component.ts
+++ b/angular-frontend/src/app/features/examples/phase3-showcase.component.ts
@@ -38,10 +38,10 @@ import { AdvancedSwipeDirective } from '../../shared/directives/advanced-swipe.d
         <h1>Phase 3: Mobile UX Showcase</h1>
         <div class="viewport-info">
           <span class="info-item">{{ currentViewport?.breakpoint | uppercase }}</span>
-          <span class="info-item" *ngIf="currentViewport?.isMobile">📱 Mobile</span>
-          <span class="info-item" *ngIf="currentViewport?.isTablet">📋 Tablet</span>
-          <span class="info-item" *ngIf="currentViewport?.isDesktop">🖥️ Desktop</span>
-          <span class="info-item" *ngIf="currentViewport?.supportsTouchscreen">👆 Touch</span>
+          <span class="info-item" *ngIf="currentViewport?.isMobile">Mobile</span>
+          <span class="info-item" *ngIf="currentViewport?.isTablet">Tablet</span>
+          <span class="info-item" *ngIf="currentViewport?.isDesktop">Desktop</span>
+          <span class="info-item" *ngIf="currentViewport?.supportsTouchscreen">Touch</span>
         </div>
       </header>
 
@@ -74,8 +74,8 @@ import { AdvancedSwipeDirective } from '../../shared/directives/advanced-swipe.d
             </div>
 
             <div class="swipe-hints">
-              <span class="hint left">❌ Pass</span>
-              <span class="hint right">💝 Connect</span>
+              <span class="hint left">Pass</span>
+              <span class="hint right">Connect</span>
             </div>
           </div>
         </div>
@@ -135,28 +135,28 @@ import { AdvancedSwipeDirective } from '../../shared/directives/advanced-swipe.d
               class="btn btn-energy-soulmate"
               (click)="triggerCelebration()"
             >
-              Celebrate! 🎉
+              Celebrate!
             </button>
           </div>
 
           <div class="animation-targets">
             <div class="animation-target breathe-target" #breatheTarget>
               <div class="target-content">
-                <span class="target-emoji">😌</span>
+                <span class="target-emoji"></span>
                 <span class="target-label">Breathing</span>
               </div>
             </div>
 
             <div class="animation-target particle-container" #particleContainer>
               <div class="target-content">
-                <span class="target-emoji">✨</span>
+                <span class="target-emoji"></span>
                 <span class="target-label">Particles</span>
               </div>
             </div>
 
             <div class="animation-target celebration-target" #celebrationTarget>
               <div class="target-content">
-                <span class="target-emoji">🎊</span>
+                <span class="target-emoji"></span>
                 <span class="target-label">Celebrate</span>
               </div>
             </div>
@@ -226,11 +226,11 @@ import { AdvancedSwipeDirective } from '../../shared/directives/advanced-swipe.d
         <div class="haptic-status">
           <p>
             <strong>Haptic Support:</strong>
-            {{ hapticStatus?.supported ? '✅ Supported' : '❌ Not Supported' }}
+            {{ hapticStatus?.supported ? 'Supported' : 'Not Supported' }}
           </p>
           <p>
             <strong>Mobile Device:</strong>
-            {{ hapticStatus?.mobile ? '✅ Yes' : '❌ No' }}
+            {{ hapticStatus?.mobile ? 'Yes' : 'No' }}
           </p>
         </div>
       </section>
@@ -742,7 +742,7 @@ export class Phase3ShowcaseComponent implements OnInit, OnDestroy {
         id: 'pass',
         direction: 'left',
         threshold: 100,
-        icon: '❌',
+        icon: 'close',
         label: 'Pass',
         color: '#e53e3e',
         hapticPattern: [50, 30, 50],
@@ -754,7 +754,7 @@ export class Phase3ShowcaseComponent implements OnInit, OnDestroy {
         id: 'connect',
         direction: 'right',
         threshold: 100,
-        icon: '💝',
+        icon: 'favorite',
         label: 'Connect',
         color: '#38a169',
         hapticPattern: [100, 50, 150, 50, 100],
@@ -881,10 +881,10 @@ export class Phase3ShowcaseComponent implements OnInit, OnDestroy {
 
   getEnergyEmoji(energy: ConnectionEnergy): string {
     const emojis = {
-      low: '💤',
-      medium: '💙',
-      high: '💜',
-      soulmate: '✨'
+      low: 'bedtime',
+      medium: 'favorite',
+      high: 'favorite',
+      soulmate: 'auto_awesome'
     };
     return emojis[energy];
   }

--- a/angular-frontend/src/app/features/landing/landing.component.html
+++ b/angular-frontend/src/app/features/landing/landing.component.html
@@ -2,7 +2,7 @@
   <!-- Hero Section -->
   <div class="hero-section">
     <mat-toolbar>
-      <span class="app-logo">💫 Dinner First: Soul Before Skin</span>
+      <span class="app-logo"><mat-icon class="logo-icon">local_dining</mat-icon> Dinner First</span>
       <span class="spacer"></span>
       <app-theme-toggle></app-theme-toggle>
       <button mat-stroked-button color="secondary" (click)="navigateToLogin()">Sign In</button>
@@ -19,9 +19,9 @@
       </div>
       <div class="hero-image">
         <div class="soul-connection-visual">
-          <div class="soul-orb">✨</div>
+          <div class="soul-orb"><mat-icon>favorite</mat-icon></div>
           <div class="connection-lines"></div>
-          <div class="soul-orb">💫</div>
+          <div class="soul-orb"><mat-icon>auto_awesome</mat-icon></div>
         </div>
       </div>
     </div>
@@ -40,7 +40,7 @@
     <div class="features-grid">
       <mat-card class="feature-card">
         <mat-card-content>
-          <div class="feature-icon">✨</div>
+          <div class="feature-icon"><mat-icon>psychology</mat-icon></div>
           <h3>Emotional Onboarding</h3>
           <p>Share your values, dreams, and what makes you feel truly understood through thoughtful questions designed to reveal your authentic self.</p>
         </mat-card-content>
@@ -48,7 +48,7 @@
 
       <mat-card class="feature-card">
         <mat-card-content>
-          <div class="feature-icon">💫</div>
+          <div class="feature-icon"><mat-icon>diversity_3</mat-icon></div>
           <h3>Soul-Based Matching</h3>
           <p>Our local algorithms match you based on compatibility of values, interests, and emotional depth - not just physical appearance.</p>
         </mat-card-content>
@@ -56,7 +56,7 @@
 
       <mat-card class="feature-card">
         <mat-card-content>
-          <div class="feature-icon">📝</div>
+          <div class="feature-icon"><mat-icon>calendar_today</mat-icon></div>
           <h3>7-Day Revelation Cycle</h3>
           <p>Share meaningful revelations with your matches over 7 days, building deep emotional connection before photo reveals.</p>
         </mat-card-content>
@@ -64,7 +64,7 @@
 
       <mat-card class="feature-card">
         <mat-card-content>
-          <div class="feature-icon">🎉</div>
+          <div class="feature-icon"><mat-icon>photo_camera</mat-icon></div>
           <h3>Photo Reveal & Beyond</h3>
           <p>After building soul connection, mutually consent to photo reveals and plan your first dinner date with someone who truly knows you.</p>
         </mat-card-content>
@@ -79,21 +79,21 @@
       <mat-card class="testimonial-card">
         <mat-card-content>
           <p>"Through 7 days of sharing our deepest thoughts, we built an incredible connection before ever seeing each other. When we finally met for dinner, it felt like reconnecting with my soulmate."</p>
-          <p class="testimonial-author">- Sarah & Michael ✨</p>
+          <p class="testimonial-author">— Sarah & Michael</p>
         </mat-card-content>
       </mat-card>
 
       <mat-card class="testimonial-card">
         <mat-card-content>
           <p>"The Soul Before Skin approach changed everything for me. I found someone who truly understands my values and dreams. Our emotional connection was so strong that physical attraction followed naturally."</p>
-          <p class="testimonial-author">- James & Emily 💫</p>
+          <p class="testimonial-author">— James & Emily</p>
         </mat-card-content>
       </mat-card>
 
       <mat-card class="testimonial-card">
         <mat-card-content>
           <p>"I was skeptical about not seeing photos first, but the revelation process helped me discover what really matters. We're planning our third dinner date and I've never felt more emotionally connected."</p>
-          <p class="testimonial-author">- Alex & Jordan 💝</p>
+          <p class="testimonial-author">— Alex & Jordan</p>
         </mat-card-content>
       </mat-card>
     </div>
@@ -104,7 +104,7 @@
     <h2>Join thousands discovering authentic soul connections</h2>
     <p class="cta-subtitle">Experience dating that prioritizes emotional depth and meaningful connection</p>
     <button mat-raised-button color="secondary" (click)="navigateToRegister()">
-      ✨ Start Your Soul Journey
+      Start Your Soul Journey
     </button>
   </div>
 
@@ -112,7 +112,7 @@
   <footer>
     <div class="footer-content">
       <div class="footer-section">
-        <h3>💫 Dinner First: Soul Before Skin</h3>
+        <h3>Dinner First</h3>
         <p>Connecting souls through meaningful conversation, leading to authentic dinner dates. Experience dating that values emotional depth over superficial attraction.</p>
       </div>
 

--- a/angular-frontend/src/app/features/landing/landing.component.scss
+++ b/angular-frontend/src/app/features/landing/landing.component.scss
@@ -16,6 +16,14 @@
       font-weight: bold;
     }
 
+    .logo-icon {
+      font-size: 24px;
+      width: 24px;
+      height: 24px;
+      vertical-align: middle;
+      margin-right: 4px;
+    }
+
     .spacer {
       flex: 1;
     }
@@ -86,9 +94,17 @@
   padding: 2rem;
 
   .soul-orb {
-    font-size: 4rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     animation: pulse 2s infinite;
-    filter: drop-shadow(0 0 20px rgba(255, 215, 0, 0.5));
+
+    mat-icon {
+      font-size: 36px;
+      width: 36px;
+      height: 36px;
+      color: white;
+    }
   }
 
   .connection-lines {
@@ -169,18 +185,21 @@
   }
 
   .feature-icon {
-    font-size: 3.5rem;
-    margin-bottom: 16px;
-    display: block;
-    filter: drop-shadow(0 0 10px rgba(102, 126, 234, 0.3));
-  }
+    width: 64px;
+    height: 64px;
+    border-radius: 50%;
+    background: rgba(var(--primary-color-rgb), 0.1);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: 0 auto 1rem;
 
-  mat-icon {
-    font-size: 60px;
-    height: 60px;
-    width: 60px;
-    margin-bottom: 16px;
-    color: var(--primary-color);
+    mat-icon {
+      font-size: 32px;
+      width: 32px;
+      height: 32px;
+      color: var(--interactive-primary);
+    }
   }
 
   h3 {

--- a/angular-frontend/src/app/features/matches/matches.component.ts
+++ b/angular-frontend/src/app/features/matches/matches.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { MatIconModule } from '@angular/material/icon';
 import { Router } from '@angular/router';
 import { SoulConnectionService } from '../../core/services/soul-connection.service';
 import { RevelationService } from '../../core/services/revelation.service';
@@ -8,7 +9,7 @@ import { SoulConnection } from '../../core/interfaces/soul-connection.interfaces
 @Component({
   selector: 'app-matches',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, MatIconModule],
   template: `
     <div class="matches-container">
       <header class="matches-header">
@@ -89,7 +90,7 @@ import { SoulConnection } from '../../core/interfaces/soul-connection.interfaces
 
           <div class="connection-actions">
             <button type="button" class="action-btn primary" (click)="startConversation(connection, $event)">
-              <span>💬</span> Continue Chat
+              <mat-icon>forum</mat-icon> Continue Chat
             </button>
             <button
               type="button"
@@ -97,7 +98,7 @@ import { SoulConnection } from '../../core/interfaces/soul-connection.interfaces
               (click)="viewRevelations(connection, $event)"
               *ngIf="connection.reveal_day > 1"
             >
-              <span>✨</span> View Revelations
+              <mat-icon>auto_awesome</mat-icon> View Revelations
             </button>
           </div>
         </button>
@@ -105,11 +106,11 @@ import { SoulConnection } from '../../core/interfaces/soul-connection.interfaces
 
       <ng-template #noConnections>
         <div class="empty-state">
-          <div class="empty-icon">💫</div>
+          <div class="empty-icon"><mat-icon>stars</mat-icon></div>
           <h2>No Soul Connections Yet</h2>
           <p>Start discovering meaningful connections based on emotional compatibility</p>
           <button type="button" class="cta-button" (click)="goToDiscover()">
-            <span>🔍</span> Discover Connections
+            <mat-icon>search</mat-icon> Discover Connections
           </button>
         </div>
       </ng-template>

--- a/angular-frontend/src/app/features/messages/conversations-empty-state.component.ts
+++ b/angular-frontend/src/app/features/messages/conversations-empty-state.component.ts
@@ -42,35 +42,35 @@ export class ConversationsEmptyStateComponent {
 
   conversationTips = [
     {
-      icon: "💭",
+      icon: "chat_bubble",
       text: "Ask about their dreams and aspirations rather than surface topics"
     },
     {
-      icon: "🎯",
+      icon: "track_changes",
       text: "Share personal stories and experiences that shaped you"
     },
     {
-      icon: "🌱",
+      icon: "spa",
       text: "Focus on values and beliefs rather than just hobbies"
     },
     {
-      icon: "💝",
+      icon: "favorite",
       text: "Be vulnerable and authentic - it creates deeper bonds"
     },
     {
-      icon: "🌟",
+      icon: "star",
       text: "Listen actively and ask follow-up questions to show genuine interest"
     }
   ];
 
   primaryAction = {
     text: "Find Soul Connections",
-    icon: "💫"
+    icon: "stars"
   };
 
   secondaryAction = {
     text: "Conversation Guide",
-    icon: "📖"
+    icon: "menu_book"
   };
 
   onDiscoverMatches() {

--- a/angular-frontend/src/app/features/messages/messages.component.ts
+++ b/angular-frontend/src/app/features/messages/messages.component.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { MatIconModule } from '@angular/material/icon';
 import { Router } from '@angular/router';
 import { SoulConnectionService } from '../../core/services/soul-connection.service';
 import { ChatService } from '../../core/services/chat.service';
@@ -37,7 +38,7 @@ type MessageFilter = 'all' | 'unread' | 'revealing';
 @Component({
   selector: 'app-messages',
   standalone: true,
-  imports: [CommonModule, ConversationsEmptyStateComponent, SwipeDirective],
+  imports: [CommonModule, MatIconModule, ConversationsEmptyStateComponent, SwipeDirective],
   template: `
     <div class="messages-container">
       <header class="messages-header">
@@ -121,7 +122,7 @@ type MessageFilter = 'all' | 'unread' | 'revealing';
                   {{message.unreadCount}}
                 </span>
                 <span class="revelation-badge" *ngIf="message.revelationDay === 7">
-                  ✨ Photo Day!
+                  <mat-icon>auto_awesome</mat-icon> Photo Day!
                 </span>
               </div>
             </div>
@@ -129,7 +130,7 @@ type MessageFilter = 'all' | 'unread' | 'revealing';
 
           <div class="message-actions" role="group" aria-label="Message actions">
             <button type="button" class="action-btn" (click)="quickReply(message, $event)" title="Quick Reply">
-              💬
+              <mat-icon>forum</mat-icon>
             </button>
             <button
               type="button"
@@ -138,10 +139,10 @@ type MessageFilter = 'all' | 'unread' | 'revealing';
               *ngIf="message.revelationDay > 1"
               title="View Revelations"
             >
-              ✨
+              <mat-icon>auto_awesome</mat-icon>
             </button>
             <button type="button" class="action-btn" (click)="toggleMute(message, $event)" title="Mute">
-              🔔
+              <mat-icon>notifications</mat-icon>
             </button>
           </div>
         </button>
@@ -156,7 +157,7 @@ type MessageFilter = 'all' | 'unread' | 'revealing';
 
       <div class="floating-action">
         <button class="fab" (click)="newMessage()" title="New Message">
-          <span>✍️</span>
+          <mat-icon>edit</mat-icon>
         </button>
       </div>
 

--- a/angular-frontend/src/app/features/messaging/messaging.component.html
+++ b/angular-frontend/src/app/features/messaging/messaging.component.html
@@ -164,8 +164,8 @@
       </div>
 
       <div class="input-wrapper">
-        <button type="button" class="emoji-picker-button" (click)="showEmojiPicker = !showEmojiPicker">
-          😊
+        <button type="button" class="emoji-picker-button" (click)="showEmojiPicker = !showEmojiPicker" aria-label="Open emoji picker">
+          <mat-icon>sentiment_satisfied_alt</mat-icon>
         </button>
 
         <textarea

--- a/angular-frontend/src/app/features/messaging/messaging.component.ts
+++ b/angular-frontend/src/app/features/messaging/messaging.component.ts
@@ -1,6 +1,10 @@
 import { Component, OnInit, OnDestroy, ViewChild, ElementRef } from '@angular/core';
-import { FormControl } from '@angular/forms';
+import { CommonModule } from '@angular/common';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
+import { MatIconModule } from '@angular/material/icon';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { ScrollingModule } from '@angular/cdk/scrolling';
 import { Subscription } from 'rxjs';
 import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
 import { Message, MessageService } from '../../core/services/message.service';
@@ -30,6 +34,14 @@ interface TypingIndicator {
 
 @Component({
   selector: 'app-messaging',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatIconModule,
+    MatProgressSpinnerModule,
+    ScrollingModule
+  ],
   templateUrl: './messaging.component.html',
   styleUrls: ['./messaging.component.scss']
 })

--- a/angular-frontend/src/app/features/notifications/notifications.component.ts
+++ b/angular-frontend/src/app/features/notifications/notifications.component.ts
@@ -79,14 +79,14 @@ import { NotificationService, Notification } from '../../core/services/notificat
               *ngIf="!notification.isRead"
               title="Mark as read"
             >
-              ✓
+              <mat-icon>done</mat-icon>
             </button>
             <button
               class="action-btn-small secondary"
               (click)="removeNotification(notification, $event)"
               title="Remove"
             >
-              ✕
+              <mat-icon>close</mat-icon>
             </button>
           </div>
         </button>

--- a/angular-frontend/src/app/features/notifications/notifications.component.ts
+++ b/angular-frontend/src/app/features/notifications/notifications.component.ts
@@ -1,12 +1,13 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Router } from '@angular/router';
+import { MatIconModule } from '@angular/material/icon';
 import { NotificationService, Notification } from '../../core/services/notification.service';
 
 @Component({
   selector: 'app-notifications',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, MatIconModule],
   template: `
     <div class="notifications-container">
       <header class="notifications-header">
@@ -54,7 +55,7 @@ import { NotificationService, Notification } from '../../core/services/notificat
           (click)="handleNotificationClick(notification)"
         >
           <div class="notification-icon">
-            <span>{{getNotificationIcon(notification.type)}}</span>
+            <mat-icon>{{getNotificationIcon(notification.type)}}</mat-icon>
           </div>
 
           <div class="notification-content">
@@ -93,11 +94,11 @@ import { NotificationService, Notification } from '../../core/services/notificat
 
       <ng-template #noNotifications>
         <div class="empty-state">
-          <div class="empty-icon">🔔</div>
+          <div class="empty-icon"><mat-icon>notifications_none</mat-icon></div>
           <h2>No Notifications</h2>
           <p>You're all caught up! Check back later for updates on your soul connections.</p>
           <button class="cta-button" (click)="simulateNotification()">
-            <span>🧪</span> Simulate Notification
+            <mat-icon class="inline-icon">science</mat-icon> Simulate Notification
           </button>
         </div>
       </ng-template>
@@ -106,25 +107,9 @@ import { NotificationService, Notification } from '../../core/services/notificat
       <div class="notification-legend" *ngIf="notifications.length > 0">
         <h3>Notification Types</h3>
         <div class="legend-items">
-          <div class="legend-item">
-            <span class="legend-icon">✨</span>
-            <span>Revelations - Someone shared a revelation</span>
-          </div>
-          <div class="legend-item">
-            <span class="legend-icon">💬</span>
-            <span>Messages - New messages received</span>
-          </div>
-          <div class="legend-item">
-            <span class="legend-icon">💫</span>
-            <span>Matches - New soul connections found</span>
-          </div>
-          <div class="legend-item">
-            <span class="legend-icon">🎉</span>
-            <span>Photo Reveals - Mutual photo reveal ready</span>
-          </div>
-          <div class="legend-item">
-            <span class="legend-icon">🔔</span>
-            <span>System - App updates and reminders</span>
+          <div class="legend-item" *ngFor="let type of ['revelation', 'message', 'match', 'photo_reveal', 'system']">
+            <mat-icon class="legend-icon">{{getNotificationIcon(type)}}</mat-icon>
+            <span>{{formatNotificationType(type)}} - {{getLegendDescription(type)}}</span>
           </div>
         </div>
       </div>
@@ -541,14 +526,25 @@ export class NotificationsComponent implements OnInit {
   }
 
   getNotificationIcon(type: string): string {
-    const icons = {
-      revelation: '✨',
-      message: '💬',
-      match: '💫',
-      photo_reveal: '🎉',
-      system: '🔔'
+    const icons: Record<string, string> = {
+      revelation: 'auto_awesome',
+      message: 'forum',
+      match: 'diversity_3',
+      photo_reveal: 'photo_camera',
+      system: 'notifications'
     };
-    return icons[type as keyof typeof icons] || '🔔';
+    return icons[type] || 'notifications';
+  }
+
+  getLegendDescription(type: string): string {
+    const descriptions: Record<string, string> = {
+      revelation: 'Someone shared a revelation',
+      message: 'New messages received',
+      match: 'New soul connections found',
+      photo_reveal: 'Mutual photo reveal ready',
+      system: 'App updates and reminders'
+    };
+    return descriptions[type] || '';
   }
 
   formatNotificationType(type: string): string {

--- a/angular-frontend/src/app/features/onboarding/interest-selection/interest-selection.component.ts
+++ b/angular-frontend/src/app/features/onboarding/interest-selection/interest-selection.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit, Output, EventEmitter } from '@angular/core';
 import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
 import { CommonModule } from '@angular/common';
+import { MatIconModule } from '@angular/material/icon';
 import { StorageService } from '../../../core/services/storage.service';
 import { SkeletonLoaderComponent } from '@shared/components/skeleton-loader/skeleton-loader.component';
 
@@ -14,7 +15,7 @@ interface InterestCategory {
 @Component({
   selector: 'app-interest-selection',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, SkeletonLoaderComponent],
+  imports: [CommonModule, MatIconModule, ReactiveFormsModule, SkeletonLoaderComponent],
   template: `
     <div class="interest-selection">
       <div class="selection-header">
@@ -35,7 +36,7 @@ interface InterestCategory {
             class="category-section">
 
             <h3 class="category-title">
-              <span class="category-icon">{{ category.icon }}</span>
+              <mat-icon class="category-icon">{{ category.icon }}</mat-icon>
               {{ category.name }}
             </h3>
 
@@ -336,32 +337,32 @@ export class InterestSelectionComponent implements OnInit {
   interestCategories: InterestCategory[] = [
     {
       name: 'Food & Dining',
-      icon: '🍽️',
+      icon: 'restaurant',
       interests: ['Cooking', 'Fine Dining', 'Street Food', 'Wine Tasting', 'Coffee Culture', 'Vegetarian/Vegan', 'Food Photography', 'Farmers Markets']
     },
     {
       name: 'Arts & Culture',
-      icon: '🎨',
+      icon: 'palette',
       interests: ['Museums', 'Theater', 'Live Music', 'Art Galleries', 'Photography', 'Writing', 'Poetry', 'Film & Cinema']
     },
     {
       name: 'Outdoor & Adventure',
-      icon: '🏔️',
+      icon: 'terrain',
       interests: ['Hiking', 'Rock Climbing', 'Cycling', 'Camping', 'Beach Activities', 'Skiing', 'Kayaking', 'Travel']
     },
     {
       name: 'Wellness & Mindfulness',
-      icon: '🧘',
+      icon: 'self_improvement',
       interests: ['Yoga', 'Meditation', 'Fitness', 'Running', 'Mental Health', 'Spirituality', 'Healthy Living', 'Nature Walks']
     },
     {
       name: 'Learning & Growth',
-      icon: '📚',
+      icon: 'menu_book',
       interests: ['Reading', 'Podcasts', 'Languages', 'History', 'Science', 'Philosophy', 'Documentaries', 'Online Courses']
     },
     {
       name: 'Social & Games',
-      icon: '🎲',
+      icon: 'casino',
       interests: ['Board Games', 'Trivia', 'Dancing', 'Karaoke', 'Video Games', 'Social Causes', 'Volunteering', 'Community Events']
     }
   ];

--- a/angular-frontend/src/app/features/onboarding/onboarding-complete/onboarding-complete.component.ts
+++ b/angular-frontend/src/app/features/onboarding/onboarding-complete/onboarding-complete.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { finalize } from 'rxjs/operators';
 import { CommonModule } from '@angular/common';
+import { MatIconModule } from '@angular/material/icon';
 import { AuthService } from '../../../core/services/auth.service';
 import { RevelationService } from '../../../core/services/revelation.service';
 import { StorageService } from '../../../core/services/storage.service';
@@ -10,11 +11,11 @@ import { EmotionalOnboarding } from '../../../core/interfaces/revelation.interfa
 @Component({
   selector: 'app-onboarding-complete',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, MatIconModule],
   template: `
     <div class="onboarding-complete">
       <div class="completion-content" *ngIf="!isSubmitting">
-        <div class="success-icon">✨</div>
+        <div class="success-icon"><mat-icon>auto_awesome</mat-icon></div>
 
         <h1>Welcome to Soul Before Skin</h1>
         <p class="welcome-message">
@@ -26,19 +27,19 @@ import { EmotionalOnboarding } from '../../../core/interfaces/revelation.interfa
           <h3>Your Soul Profile Includes:</h3>
           <ul class="profile-features">
             <li>
-              <span class="feature-icon">💭</span>
+              <mat-icon class="feature-icon">chat_bubble</mat-icon>
               Deep emotional insights and relationship values
             </li>
             <li>
-              <span class="feature-icon">🤝</span>
+              <mat-icon class="feature-icon">handshake</mat-icon>
               Personality traits and communication style
             </li>
             <li>
-              <span class="feature-icon">❤️</span>
+              <mat-icon class="feature-icon">favorite</mat-icon>
               {{ totalInterests }} carefully selected interests
             </li>
             <li>
-              <span class="feature-icon">🎯</span>
+              <mat-icon class="feature-icon">track_changes</mat-icon>
               Compatibility scoring with local algorithms
             </li>
           </ul>
@@ -82,7 +83,7 @@ import { EmotionalOnboarding } from '../../../core/interfaces/revelation.interfa
       </div>
 
       <div class="error-content" *ngIf="hasError">
-        <div class="error-icon">⚠️</div>
+        <div class="error-icon"><mat-icon>warning</mat-icon></div>
         <h2>Something went wrong</h2>
         <p>{{ errorMessage }}</p>
         <button class="btn btn-outline" (click)="retrySubmission()">

--- a/angular-frontend/src/app/features/profile/profile-empty-state.component.ts
+++ b/angular-frontend/src/app/features/profile/profile-empty-state.component.ts
@@ -49,35 +49,35 @@ export class ProfileEmptyStateComponent {
 
   profileTips = [
     {
-      icon: "💭",
+      icon: "chat_bubble",
       text: "Share your life philosophy and core values that guide you"
     },
     {
-      icon: "🎯",
+      icon: "track_changes",
       text: "Describe your interests and passions in authentic detail"
     },
     {
-      icon: "💖",
+      icon: "favorite",
       text: "Express what you're looking for in a meaningful connection"
     },
     {
-      icon: "✨",
+      icon: "auto_awesome",
       text: "Add thoughtful photos that reflect your genuine personality"
     },
     {
-      icon: "🌟",
+      icon: "star",
       text: "Write prompts that invite deeper conversation and understanding"
     }
   ];
 
   primaryAction = {
     text: "Complete Your Profile",
-    icon: "✨"
+    icon: "auto_awesome"
   };
 
   secondaryAction = {
     text: "Add Photos",
-    icon: "📸"
+    icon: "photo_camera"
   };
 
   onCompleteProfile() {

--- a/angular-frontend/src/app/features/profile/profile-view/profile-view.component.ts
+++ b/angular-frontend/src/app/features/profile/profile-view/profile-view.component.ts
@@ -89,7 +89,7 @@ export class ProfileViewComponent implements OnInit {
 
   getCompletionMessage(): string {
     if (this.profileCompletion >= 90) {
-      return 'Your profile is looking great! 🎉';
+      return 'Your profile is looking great!';
     } else if (this.profileCompletion >= 70) {
       return 'Almost there! A few more details would help.';
     } else if (this.profileCompletion >= 50) {

--- a/angular-frontend/src/app/features/revelations/revelation-timeline.component.ts
+++ b/angular-frontend/src/app/features/revelations/revelation-timeline.component.ts
@@ -4,6 +4,7 @@
  */
 import { Component, Input, Output, EventEmitter, OnInit, OnDestroy, ChangeDetectionStrategy, ViewChild, ElementRef } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { MatIconModule } from '@angular/material/icon';
 import { Subject } from 'rxjs';
 import { HapticFeedbackService } from '../../core/services/haptic-feedback.service';
 
@@ -41,7 +42,7 @@ export interface RevelationDayData {
 @Component({
   selector: 'app-revelation-timeline',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, MatIconModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div class="revelation-timeline-container" [attr.data-phase]="timelineData?.visualization.phase">
@@ -124,10 +125,10 @@ export interface RevelationDayData {
             <div class="day-number">{{ dayData.day }}</div>
             <div class="day-status">
               <div class="user-status" [class.completed]="dayData.userShared">
-                {{ dayData.userShared ? '✨' : '○' }}
+                {{ dayData.userShared ? '\u2713' : '\u25CB' }}
               </div>
               <div class="partner-status" [class.completed]="dayData.partnerShared">
-                {{ dayData.partnerShared ? '💫' : '○' }}
+                {{ dayData.partnerShared ? '\u2713' : '\u25CB' }}
               </div>
             </div>
           </div>
@@ -163,7 +164,7 @@ export interface RevelationDayData {
 
           <!-- Locked day indicator -->
           <div class="day-locked" *ngIf="!dayData.isUnlocked">
-            <div class="lock-icon">🔒</div>
+            <div class="lock-icon"><mat-icon>lock</mat-icon></div>
             <div class="unlock-info">
               <span *ngIf="dayData.day === (timelineData?.currentDay || 1) + 1">
                 Unlocks tomorrow
@@ -194,7 +195,7 @@ export interface RevelationDayData {
           [disabled]="hasSharedToday()"
           [attr.aria-label]="getShareButtonLabel()"
         >
-          <span class="btn-icon">✨</span>
+          <mat-icon class="btn-icon">auto_awesome</mat-icon>
           <span class="btn-text">
             {{ hasSharedToday() ? 'Shared Today' : 'Share Your Soul' }}
           </span>
@@ -205,7 +206,7 @@ export interface RevelationDayData {
       <div class="photo-reveal-section" *ngIf="isPhotoRevealDay()">
         <div class="photo-reveal-card">
           <div class="reveal-header">
-            <h3>Photo Reveal Day! 📸</h3>
+            <h3>Photo Reveal Day!</h3>
             <p>After sharing your souls this week, are you ready to see each other?</p>
           </div>
 
@@ -216,12 +217,12 @@ export interface RevelationDayData {
               (click)="givePhotoConsent()"
               [disabled]="hasGivenConsent()"
             >
-              {{ hasGivenConsent() ? 'Consent Given ✓' : "I'm Ready to Reveal" }}
+              {{ hasGivenConsent() ? 'Consent Given' : "I'm Ready to Reveal" }}
             </button>
           </div>
 
           <div class="photos-revealed" *ngIf="isMutualConsentGiven()">
-            <div class="celebration">🎉 Photos Revealed! 🎉</div>
+            <div class="celebration">Photos Revealed!</div>
             <p>You can now see each other's photos in your connection.</p>
           </div>
         </div>

--- a/angular-frontend/src/app/features/revelations/revelations-empty-state.component.ts
+++ b/angular-frontend/src/app/features/revelations/revelations-empty-state.component.ts
@@ -46,43 +46,43 @@ export class RevelationsEmptyStateComponent {
 
   revelationTips = [
     {
-      icon: "1️⃣",
+      icon: "looks_one",
       text: "Day 1: Share a core value that guides your life decisions"
     },
     {
-      icon: "2️⃣",
+      icon: "looks_two",
       text: "Day 2: Describe a meaningful experience that shaped you"
     },
     {
-      icon: "3️⃣",
+      icon: "looks_3",
       text: "Day 3: Share a hope or dream close to your heart"
     },
     {
-      icon: "4️⃣",
+      icon: "looks_4",
       text: "Day 4: Reveal what genuinely makes you laugh and feel joy"
     },
     {
-      icon: "5️⃣",
+      icon: "looks_5",
       text: "Day 5: Share a challenge you overcame and learned from"
     },
     {
-      icon: "6️⃣",
+      icon: "looks_6",
       text: "Day 6: Describe your vision of an ideal emotional connection"
     },
     {
-      icon: "7️⃣",
+      icon: "filter_7",
       text: "Day 7: Mutual photo reveal and plan your first soul dinner"
     }
   ];
 
   primaryAction = {
     text: "Begin Soul Revelations",
-    icon: "✨"
+    icon: "auto_awesome"
   };
 
   secondaryAction = {
     text: "Learn More",
-    icon: "📚"
+    icon: "menu_book"
   };
 
   onStartJourney() {

--- a/angular-frontend/src/app/features/revelations/revelations.component.ts
+++ b/angular-frontend/src/app/features/revelations/revelations.component.ts
@@ -4,6 +4,7 @@ import { FormsModule, ReactiveFormsModule, FormBuilder, FormGroup, Validators } 
 import { ActivatedRoute, Router } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { MatIconModule } from '@angular/material/icon';
 import { RevelationService } from '../../core/services/revelation.service';
 import { SoulConnectionService } from '../../core/services/soul-connection.service';
 import { HapticFeedbackService } from '../../core/services/haptic-feedback.service';
@@ -21,7 +22,7 @@ import {
 @Component({
   selector: 'app-revelations',
   standalone: true,
-  imports: [CommonModule, FormsModule, ReactiveFormsModule, RevelationsEmptyStateComponent, MatDialogModule],
+  imports: [CommonModule, FormsModule, ReactiveFormsModule, RevelationsEmptyStateComponent, MatDialogModule, MatIconModule],
   template: `
     <div class="revelations-container" #revelationContainer>
       <header class="revelations-header">
@@ -38,9 +39,9 @@ import {
         <div class="progress-header">
           <h2>Day {{timeline.current_day}} of 7</h2>
           <span class="completion-status" [class.complete]="timeline.is_cycle_complete">
-            {{timeline.is_cycle_complete ? 'Cycle Complete! 🎉' : 'In Progress...'}}
+            {{timeline.is_cycle_complete ? 'Cycle Complete' : 'In Progress...'}}
           </span>
-          <span class="streak-badge" *ngIf="streakCount > 0">🔥 {{streakCount}} day streak</span>
+          <span class="streak-badge" *ngIf="streakCount > 0"><mat-icon class="inline-icon">local_fire_department</mat-icon> {{streakCount}} day streak</span>
         </div>
 
         <div class="progress-visual">
@@ -119,8 +120,8 @@ import {
                 class="share-btn"
                 [disabled]="revelationForm.invalid || submitting"
               >
-                <span *ngIf="!submitting">✨ Share Revelation</span>
-                <span *ngIf="submitting">Sharing... 💫</span>
+                <span *ngIf="!submitting">Share Revelation</span>
+                <span *ngIf="submitting">Sharing...</span>
               </button>
             </div>
           </form>
@@ -164,10 +165,10 @@ import {
 
             <div class="revelation-actions" *ngIf="revelation.sender_id !== currentUserId">
               <button class="action-btn" (click)="markAsRead(revelation)">
-                <span>👀</span> Read
+                <mat-icon class="inline-icon">visibility</mat-icon> Read
               </button>
               <button class="action-btn" (click)="reactToRevelation(revelation)">
-                <span>💝</span> React
+                <mat-icon class="inline-icon">favorite</mat-icon> React
               </button>
             </div>
           </div>
@@ -178,7 +179,7 @@ import {
       <div class="photo-reveal-section" *ngIf="timeline?.current_day === 7 || timeline?.is_cycle_complete">
         <div class="photo-reveal-card">
           <div class="photo-reveal-header">
-            <h3>🎉 Photo Reveal Day!</h3>
+            <h3>Photo Reveal Day!</h3>
             <p>You've completed your 7-day revelation journey. Ready to see each other?</p>
           </div>
 
@@ -187,13 +188,13 @@ import {
               <div class="consent-item">
                 <span class="user">You</span>
                 <span class="status" [class.agreed]="userConsent">
-                  {{userConsent ? '✅ Ready' : '⏳ Pending'}}
+                  {{userConsent ? 'Ready' : 'Pending'}}
                 </span>
               </div>
               <div class="consent-item">
                 <span class="user">{{partnerName}}</span>
                 <span class="status" [class.agreed]="partnerConsent">
-                  {{partnerConsent ? '✅ Ready' : '⏳ Pending'}}
+                  {{partnerConsent ? 'Ready' : 'Pending'}}
                 </span>
               </div>
             </div>
@@ -204,15 +205,15 @@ import {
               (click)="togglePhotoConsent()"
               [disabled]="submitting"
             >
-              {{userConsent ? '✅ You agreed to reveal' : '🤔 Agree to photo reveal'}}
+              {{userConsent ? 'You agreed to reveal' : 'Agree to photo reveal'}}
             </button>
           </div>
 
           <div class="photo-revealed" *ngIf="photoRevealed">
-            <h4>🌟 Photos Revealed!</h4>
+            <h4>Photos Revealed</h4>
             <p>You can now see each other's photos and continue your connection journey.</p>
             <button class="view-profile-btn" (click)="viewFullProfile()">
-              <span>👀</span> View Full Profile
+              <mat-icon class="inline-icon">visibility</mat-icon> View Full Profile
             </button>
           </div>
         </div>
@@ -233,6 +234,14 @@ import {
     </div>
   `,
   styles: [`
+    .inline-icon {
+      font-size: 18px;
+      width: 18px;
+      height: 18px;
+      vertical-align: middle;
+      margin-right: 4px;
+    }
+
     .revelations-container {
       max-width: 800px;
       margin: 0 auto;
@@ -1126,7 +1135,7 @@ export class RevelationsComponent implements OnInit, OnDestroy, AfterViewInit {
     });
   }
 
-  async reactToRevelation(revelation: DailyRevelation, emoji: string = '❤️') {
+  async reactToRevelation(revelation: DailyRevelation, emoji: string = 'heart') {
     try {
       await this.revelationService.reactToRevelation(revelation.id, emoji).toPromise();
 

--- a/angular-frontend/src/app/features/settings/settings-empty-state.component.ts
+++ b/angular-frontend/src/app/features/settings/settings-empty-state.component.ts
@@ -10,7 +10,7 @@ import { EmptyStateComponent } from '../../shared/components/empty-state/empty-s
     <app-empty-state
       theme="neutral"
       size="medium"
-      customIcon="⚙️"
+      customIcon="settings"
       [iconSize]="3"
       [title]="title"
       [description]="description"
@@ -38,35 +38,35 @@ export class SettingsEmptyStateComponent {
 
   settingsTips = [
     {
-      icon: "🔔",
+      icon: "notifications",
       text: "Set notification preferences for matches and messages"
     },
     {
-      icon: "🌙",
+      icon: "dark_mode",
       text: "Choose your preferred conversation times and activity periods"
     },
     {
-      icon: "🔒",
+      icon: "lock",
       text: "Configure privacy settings and photo visibility preferences"
     },
     {
-      icon: "💫",
+      icon: "stars",
       text: "Adjust matching criteria and distance preferences"
     },
     {
-      icon: "🎨",
+      icon: "palette",
       text: "Select your preferred theme and display options"
     }
   ];
 
   primaryAction = {
     text: "Set Up Notifications",
-    icon: "🔔"
+    icon: "notifications"
   };
 
   secondaryAction = {
     text: "Customize Preferences",
-    icon: "⚙️"
+    icon: "settings"
   };
 
   onConfigureNotifications() {

--- a/angular-frontend/src/app/features/settings/settings.component.ts
+++ b/angular-frontend/src/app/features/settings/settings.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { MatIconModule } from '@angular/material/icon';
 import { FormsModule, ReactiveFormsModule, FormBuilder } from '@angular/forms';
 import { Router } from '@angular/router';
 
@@ -32,7 +33,7 @@ interface AppSettings {
 @Component({
   selector: 'app-settings',
   standalone: true,
-  imports: [CommonModule, FormsModule, ReactiveFormsModule],
+  imports: [CommonModule, MatIconModule, FormsModule, ReactiveFormsModule],
   template: `
     <div class="settings-container">
       <header class="settings-header">
@@ -44,7 +45,7 @@ interface AppSettings {
         <!-- Privacy Settings -->
         <section class="settings-section">
           <div class="section-header">
-            <h2>🔒 Privacy & Visibility</h2>
+            <h2><mat-icon>lock</mat-icon> Privacy & Visibility</h2>
             <p>Control who can see your profile and information</p>
           </div>
 
@@ -110,7 +111,7 @@ interface AppSettings {
         <!-- Notification Settings -->
         <section class="settings-section">
           <div class="section-header">
-            <h2>🔔 Notifications</h2>
+            <h2><mat-icon>notifications</mat-icon> Notifications</h2>
             <p>Choose what notifications you want to receive</p>
           </div>
 
@@ -186,7 +187,7 @@ interface AppSettings {
         <!-- App Settings -->
         <section class="settings-section">
           <div class="section-header">
-            <h2>⚙️ App Preferences</h2>
+            <h2><mat-icon>settings</mat-icon> App Preferences</h2>
             <p>Customize how the app works for you</p>
           </div>
 
@@ -272,7 +273,7 @@ interface AppSettings {
         <!-- Account Actions -->
         <section class="settings-section danger-section">
           <div class="section-header">
-            <h2>⚠️ Account Management</h2>
+            <h2><mat-icon>warning</mat-icon> Account Management</h2>
             <p>Manage your account and data</p>
           </div>
 
@@ -283,7 +284,7 @@ interface AppSettings {
                 <p>Download a copy of your revelations and connections</p>
               </div>
               <button class="action-btn secondary" (click)="exportData()">
-                <span>📥</span> Export Data
+                <mat-icon>download</mat-icon> Export Data
               </button>
             </div>
 
@@ -303,7 +304,7 @@ interface AppSettings {
                 <p>Permanently delete your account and all data</p>
               </div>
               <button class="action-btn danger" (click)="deleteAccount()">
-                <span>🗑️</span> Delete Account
+                <mat-icon>delete</mat-icon> Delete Account
               </button>
             </div>
           </div>
@@ -313,10 +314,10 @@ interface AppSettings {
       <!-- Save Actions -->
       <div class="save-actions">
         <button class="save-btn" (click)="saveSettings()" [disabled]="!hasChanges">
-          <span>💾</span> Save Changes
+          <mat-icon>save</mat-icon> Save Changes
         </button>
         <button class="reset-btn" (click)="resetSettings()">
-          <span>🔄</span> Reset to Defaults
+          <mat-icon>refresh</mat-icon> Reset to Defaults
         </button>
       </div>
     </div>

--- a/angular-frontend/src/app/shared/components/compatibility-radar/compatibility-radar.component.ts
+++ b/angular-frontend/src/app/shared/components/compatibility-radar/compatibility-radar.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input, OnInit, OnDestroy, AfterViewInit, ViewChild, ElementRef, OnChanges, SimpleChanges } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { MatIconModule } from '@angular/material/icon';
 import { Subscription } from 'rxjs';
 import { CompatibilityBreakdown, CompatibilityResponse } from '../../../core/interfaces/soul-connection.interfaces';
 import { SoulConnectionService } from '../../../core/services/soul-connection.service';
@@ -7,7 +8,7 @@ import { SoulConnectionService } from '../../../core/services/soul-connection.se
 @Component({
   selector: 'app-compatibility-radar',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, MatIconModule],
   template: `
     <div class="compatibility-radar-container" [ngClass]="size">
       <div class="radar-header" *ngIf="showHeader">
@@ -175,7 +176,7 @@ import { SoulConnectionService } from '../../../core/services/soul-connection.se
             *ngFor="let insight of insights; trackBy: trackInsight"
             class="insight-item"
             [ngClass]="insight.type">
-            <div class="insight-icon">{{insight.icon}}</div>
+            <div class="insight-icon"><mat-icon>{{insight.icon}}</mat-icon></div>
             <div class="insight-text">{{insight.text}}</div>
           </div>
         </div>
@@ -697,7 +698,7 @@ export class CompatibilityRadarComponent implements OnInit, OnDestroy, AfterView
       const topStrength = strengths.reduce((a, b) => a.score > b.score ? a : b);
       this.insights.push({
         type: 'strength',
-        icon: '✨',
+        icon: 'auto_awesome',
         text: `Exceptional ${topStrength.label.toLowerCase()} compatibility (${topStrength.score}%) creates a strong foundation for soul connection.`
       });
     }
@@ -708,7 +709,7 @@ export class CompatibilityRadarComponent implements OnInit, OnDestroy, AfterView
       const topOpportunity = opportunities.reduce((a, b) => a.score > b.score ? a : b);
       this.insights.push({
         type: 'opportunity',
-        icon: '🌱',
+        icon: 'spa',
         text: `Growing ${topOpportunity.label.toLowerCase()} alignment (${topOpportunity.score}%) offers potential for deeper soul connection.`
       });
     }
@@ -719,7 +720,7 @@ export class CompatibilityRadarComponent implements OnInit, OnDestroy, AfterView
       const topConcern = concerns.reduce((a, b) => a.score < b.score ? a : b);
       this.insights.push({
         type: 'concern',
-        icon: '💭',
+        icon: 'chat_bubble',
         text: `Exploring ${topConcern.label.toLowerCase()} differences (${topConcern.score}%) through meaningful revelations could deepen understanding.`
       });
     }
@@ -729,13 +730,13 @@ export class CompatibilityRadarComponent implements OnInit, OnDestroy, AfterView
     if (overall >= 85) {
       this.insights.push({
         type: 'strength',
-        icon: '💫',
+        icon: 'stars',
         text: `Outstanding overall compatibility (${overall}%) suggests a profound soul-level connection.`
       });
     } else if (overall >= 70) {
       this.insights.push({
         type: 'opportunity',
-        icon: '🔗',
+        icon: 'link',
         text: `Strong overall compatibility (${overall}%) indicates promising potential for lasting connection.`
       });
     }

--- a/angular-frontend/src/app/shared/components/compatibility-score/compatibility-score.component.ts
+++ b/angular-frontend/src/app/shared/components/compatibility-score/compatibility-score.component.ts
@@ -1,10 +1,11 @@
 import { Component, Input, OnInit, OnDestroy, ViewChild, ElementRef, AfterViewInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { MatIconModule } from '@angular/material/icon';
 
 @Component({
   selector: 'app-compatibility-score',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, MatIconModule],
   template: `
     <div
       class="compatibility-container"
@@ -147,9 +148,9 @@ import { CommonModule } from '@angular/common';
 
       <!-- Floating hearts for high compatibility -->
       <div class="floating-hearts" *ngIf="score >= 90 && animated">
-        <div class="heart heart-1">💖</div>
-        <div class="heart heart-2">✨</div>
-        <div class="heart heart-3">💫</div>
+        <div class="heart heart-1"><mat-icon>favorite</mat-icon></div>
+        <div class="heart heart-2"><mat-icon>auto_awesome</mat-icon></div>
+        <div class="heart heart-3"><mat-icon>stars</mat-icon></div>
       </div>
     </div>
   `,
@@ -632,12 +633,12 @@ export class CompatibilityScoreComponent implements OnInit, OnDestroy, AfterView
   }
 
   getCompatibilityTitle(): string {
-    if (this.score >= 90) return '✨ Soul Connection';
-    if (this.score >= 80) return '💖 Exceptional Match';
-    if (this.score >= 70) return '💕 Strong Connection';
-    if (this.score >= 60) return '💙 Good Harmony';
-    if (this.score >= 50) return '💜 Potential Bond';
-    return '💛 Growing Connection';
+    if (this.score >= 90) return 'Soul Connection';
+    if (this.score >= 80) return 'Exceptional Match';
+    if (this.score >= 70) return 'Strong Connection';
+    if (this.score >= 60) return 'Good Harmony';
+    if (this.score >= 50) return 'Potential Bond';
+    return 'Growing Connection';
   }
 
   getCompatibilityDescription(): string {

--- a/angular-frontend/src/app/shared/components/empty-state/empty-state.component.ts
+++ b/angular-frontend/src/app/shared/components/empty-state/empty-state.component.ts
@@ -1,11 +1,12 @@
 import { Component, Input, Output, EventEmitter } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { MatIconModule } from '@angular/material/icon';
 import { SoulOrbComponent } from '../soul-orb/soul-orb.component';
 
 @Component({
   selector: 'app-empty-state',
   standalone: true,
-  imports: [CommonModule, SoulOrbComponent],
+  imports: [CommonModule, MatIconModule, SoulOrbComponent],
   template: `
     <div
       class="empty-state-container"
@@ -60,7 +61,7 @@ import { SoulOrbComponent } from '../soul-orb/soul-orb.component';
               <circle cx="100" cy="100" r="80" fill="url(#search-gradient)" class="search-pulse"/>
               <circle cx="100" cy="100" r="40" fill="#ffffff" stroke="#ff6b9d" stroke-width="3"/>
               <path d="M 120 120 L 140 140" stroke="#ff6b9d" stroke-width="4" stroke-linecap="round" class="search-handle"/>
-              <text x="100" y="106" text-anchor="middle" font-size="24" fill="#ff6b9d" aria-hidden="true">🔍</text>
+              <text x="100" y="106" text-anchor="middle" font-size="24" fill="#ff6b9d" aria-hidden="true"></text>
             </g>
 
             <!-- Conversations illustration -->
@@ -76,7 +77,7 @@ import { SoulOrbComponent } from '../soul-orb/soul-orb.component';
               <line x1="80" y1="60" x2="160" y2="60" stroke="#60a5fa" stroke-width="2"/>
               <line x1="80" y1="80" x2="140" y2="80" stroke="#60a5fa" stroke-width="2"/>
               <line x1="80" y1="100" x2="120" y2="100" stroke="#60a5fa" stroke-width="2"/>
-              <text x="190" y="50" text-anchor="middle" font-size="16" fill="#34d399" aria-hidden="true">💬</text>
+              <text x="190" y="50" text-anchor="middle" font-size="16" fill="#34d399" aria-hidden="true"></text>
             </g>
 
             <!-- Revelations illustration -->
@@ -91,7 +92,7 @@ import { SoulOrbComponent } from '../soul-orb/soul-orb.component';
               <circle cx="100" cy="100" r="90" fill="url(#revelation-gradient)" class="revelation-glow"/>
               <path d="M 100 40 L 110 70 L 140 70 L 118 90 L 128 120 L 100 105 L 72 120 L 82 90 L 60 70 L 90 70 Z"
                     fill="#ffd700" stroke="#ffffff" stroke-width="2" class="star-sparkle"/>
-              <text x="100" y="170" text-anchor="middle" font-size="20" fill="#c084fc" aria-hidden="true">✨</text>
+              <text x="100" y="170" text-anchor="middle" font-size="20" fill="#c084fc" aria-hidden="true"></text>
             </g>
 
             <!-- Profile illustration -->
@@ -105,7 +106,7 @@ import { SoulOrbComponent } from '../soul-orb/soul-orb.component';
               <circle cx="100" cy="80" r="35" fill="url(#profile-gradient)" opacity="0.8"/>
               <path d="M 60 140 Q 100 120 140 140 L 140 180 L 60 180 Z" fill="url(#profile-gradient)" opacity="0.8"/>
               <circle cx="100" cy="80" r="30" fill="#ffffff" stroke="#ec4899" stroke-width="3"/>
-              <text x="100" y="88" text-anchor="middle" font-size="24" fill="#ec4899" aria-hidden="true">👤</text>
+              <text x="100" y="88" text-anchor="middle" font-size="24" fill="#ec4899" aria-hidden="true"></text>
             </g>
 
           </svg>
@@ -113,7 +114,7 @@ import { SoulOrbComponent } from '../soul-orb/soul-orb.component';
 
         <!-- Custom icon -->
         <div *ngIf="!illustration && !showSoulOrb && customIcon" class="custom-icon">
-          <span [ngStyle]="{'font-size': iconSize + 'rem'}">{{customIcon}}</span>
+          <mat-icon [ngStyle]="{'font-size': iconSize + 'rem', 'width': iconSize + 'rem', 'height': iconSize + 'rem'}">{{customIcon}}</mat-icon>
         </div>
       </div>
 
@@ -150,11 +151,11 @@ import { SoulOrbComponent } from '../soul-orb/soul-orb.component';
               class="tip-item"
               role="listitem"
               [attr.aria-label]="getTipAriaLabel(tip, i)">
-              <span
+              <mat-icon
                 class="tip-icon"
                 aria-hidden="true">
-                {{tip.icon || '💡'}}
-              </span>
+                {{tip.icon || 'lightbulb'}}
+              </mat-icon>
               <span class="tip-text">{{tip.text}}</span>
             </li>
           </ul>
@@ -202,12 +203,12 @@ import { SoulOrbComponent } from '../soul-orb/soul-orb.component';
             (click)="onPrimaryAction()"
             (keydown)="handleActionKeydown($event, 'primary')"
             [disabled]="primaryActionDisabled">
-            <span
+            <mat-icon
               *ngIf="primaryAction.icon"
               class="btn-icon"
               aria-hidden="true">
               {{primaryAction.icon}}
-            </span>
+            </mat-icon>
             <span class="btn-text">{{primaryAction.text}}</span>
           </button>
 
@@ -220,12 +221,12 @@ import { SoulOrbComponent } from '../soul-orb/soul-orb.component';
             (click)="onSecondaryAction()"
             (keydown)="handleActionKeydown($event, 'secondary')"
             [disabled]="secondaryActionDisabled">
-            <span
+            <mat-icon
               *ngIf="secondaryAction.icon"
               class="btn-icon"
               aria-hidden="true">
               {{secondaryAction.icon}}
-            </span>
+            </mat-icon>
             <span class="btn-text">{{secondaryAction.text}}</span>
           </button>
         </div>

--- a/angular-frontend/src/app/shared/components/loading-screen/loading-screen.component.ts
+++ b/angular-frontend/src/app/shared/components/loading-screen/loading-screen.component.ts
@@ -1,11 +1,12 @@
 import { Component, Input } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { MatIconModule } from '@angular/material/icon';
 import { SkeletonLoaderComponent } from '../skeleton-loader/skeleton-loader.component';
 
 @Component({
   selector: 'app-loading-screen',
   standalone: true,
-  imports: [CommonModule, SkeletonLoaderComponent],
+  imports: [CommonModule, MatIconModule, SkeletonLoaderComponent],
   template: `
     <div class="loading-screen" [ngClass]="screenType">
 
@@ -54,9 +55,9 @@ import { SkeletonLoaderComponent } from '../skeleton-loader/skeleton-loader.comp
 
       <!-- Soul Connection Animation -->
       <div class="soul-connection-animation">
-        <div class="soul-orb primary">✨</div>
+        <div class="soul-orb primary"><mat-icon>auto_awesome</mat-icon></div>
         <div class="connection-pulse"></div>
-        <div class="soul-orb secondary">💫</div>
+        <div class="soul-orb secondary"><mat-icon>stars</mat-icon></div>
       </div>
 
       <p class="loading-text">{{ loadingText }}</p>

--- a/angular-frontend/src/app/shared/components/match-celebration/match-celebration.component.ts
+++ b/angular-frontend/src/app/shared/components/match-celebration/match-celebration.component.ts
@@ -47,7 +47,7 @@ import { SoulConfig } from '../../models/soul-types';
               [style.left.%]="heart.x"
               [style.animation-delay]="heart.delay + 's'"
               [style.animation-duration]="heart.duration + 's'">
-              {{heart.emoji}}
+              <mat-icon>{{heart.emoji}}</mat-icon>
             </div>
           </div>
         </div>
@@ -698,7 +698,7 @@ export class MatchCelebrationComponent implements OnInit, OnDestroy {
           x: Math.random() * 100,
           delay: Math.random() * 4,
           duration: 4 + Math.random() * 2,
-          emoji: '♥'
+          emoji: 'favorite'
         });
       }
     }

--- a/angular-frontend/src/app/shared/components/match-celebration/match-celebration.component.ts
+++ b/angular-frontend/src/app/shared/components/match-celebration/match-celebration.component.ts
@@ -2,12 +2,13 @@ import { Component, Input, OnInit, OnDestroy, Output, EventEmitter } from '@angu
 import { CommonModule } from '@angular/common';
 import { SoulOrbComponent } from '../soul-orb/soul-orb.component';
 import { SoulConnectionComponent } from '../soul-connection/soul-connection.component';
+import { MatIconModule } from '@angular/material/icon';
 import { SoulConfig } from '../../models/soul-types';
 
 @Component({
   selector: 'app-match-celebration',
   standalone: true,
-  imports: [CommonModule, SoulOrbComponent, SoulConnectionComponent],
+  imports: [CommonModule, MatIconModule, SoulOrbComponent, SoulConnectionComponent],
   template: `
     <button type="button" class="celebration-overlay" [class.active]="isActive" (click)="onOverlayClick()">
       <div class="celebration-container" [ngClass]="celebrationType">
@@ -34,7 +35,7 @@ import { SoulConfig } from '../../models/soul-types';
               [style.left.%]="sparkle.x"
               [style.top.%]="sparkle.y"
               [style.animation-delay]="sparkle.delay + 's'">
-              ✨
+              <mat-icon class="sparkle-icon">auto_awesome</mat-icon>
             </div>
           </div>
 
@@ -82,7 +83,7 @@ import { SoulConfig } from '../../models/soul-types';
                 *ngFor="let highlight of compatibilityHighlights; trackBy: trackHighlight"
                 class="highlight-item"
                 [ngClass]="highlight.level">
-                <div class="highlight-icon">{{highlight.icon}}</div>
+                <mat-icon class="highlight-icon">{{highlight.icon}}</mat-icon>
                 <div class="highlight-content">
                   <span class="highlight-label">{{highlight.label}}</span>
                   <span class="highlight-score">{{highlight.score}}%</span>
@@ -104,7 +105,7 @@ import { SoulConfig } from '../../models/soul-types';
               class="action-btn primary"
               (click)="onStartConversation()"
               [disabled]="isProcessing">
-              <span class="btn-icon">💬</span>
+              <mat-icon class="btn-icon">forum</mat-icon>
               <span class="btn-text">Start Soul Conversation</span>
             </button>
 
@@ -112,7 +113,7 @@ import { SoulConfig } from '../../models/soul-types';
               class="action-btn secondary"
               (click)="onViewProfile()"
               [disabled]="isProcessing">
-              <span class="btn-icon">👤</span>
+              <mat-icon class="btn-icon">person</mat-icon>
               <span class="btn-text">Explore Their Soul</span>
             </button>
 
@@ -131,7 +132,7 @@ import { SoulConfig } from '../../models/soul-types';
               <div
                 *ngFor="let insight of connectionInsights; trackBy: trackInsight"
                 class="insight-item">
-                <span class="insight-icon">{{insight.icon}}</span>
+                <mat-icon class="insight-icon">{{insight.icon}}</mat-icon>
                 <span class="insight-text">{{insight.text}}</span>
               </div>
             </div>
@@ -227,6 +228,10 @@ import { SoulConfig } from '../../models/soul-types';
       position: absolute;
       font-size: 1.5rem;
       animation: sparkle-twinkle 2s ease-in-out infinite;
+    }
+
+    .sparkle-icon {
+      color: #ffd700;
     }
 
     .hearts-container {
@@ -619,10 +624,10 @@ export class MatchCelebrationComponent implements OnInit, OnDestroy {
   }
 
   get celebrationTitle(): string {
-    if (this.compatibilityScore >= 95) return 'Perfect Soul Match! 💫';
-    if (this.compatibilityScore >= 85) return 'Exceptional Connection! ✨';
-    if (this.compatibilityScore >= 75) return 'Strong Soul Bond! 💖';
-    return 'Beautiful Match! 🌟';
+    if (this.compatibilityScore >= 95) return 'Perfect Soul Match';
+    if (this.compatibilityScore >= 85) return 'Exceptional Connection';
+    if (this.compatibilityScore >= 75) return 'Strong Soul Bond';
+    return 'Beautiful Match';
   }
 
   get celebrationSubtitle(): string {
@@ -687,14 +692,13 @@ export class MatchCelebrationComponent implements OnInit, OnDestroy {
     // Generate hearts for high compatibility
     this.heartParticles = [];
     if (this.showHearts && this.compatibilityScore >= 80) {
-      const heartEmojis = ['💖', '💕', '💗', '💘', '❤️'];
       for (let i = 0; i < 10; i++) {
         this.heartParticles.push({
           id: i,
           x: Math.random() * 100,
           delay: Math.random() * 4,
           duration: 4 + Math.random() * 2,
-          emoji: heartEmojis[Math.floor(Math.random() * heartEmojis.length)]
+          emoji: '♥'
         });
       }
     }
@@ -706,9 +710,9 @@ export class MatchCelebrationComponent implements OnInit, OnDestroy {
 
     // Mock compatibility data - in real app, this would come from matchData
     const highlights = [
-      { label: 'Core Values', score: 92, icon: '💎', color: '#ffd700' },
-      { label: 'Life Goals', score: 88, icon: '🎯', color: '#ff6b9d' },
-      { label: 'Communication', score: 85, icon: '💬', color: '#c084fc' }
+      { label: 'Core Values', score: 92, icon: 'diamond', color: '#ffd700' },
+      { label: 'Life Goals', score: 88, icon: 'track_changes', color: '#ff6b9d' },
+      { label: 'Communication', score: 85, icon: 'forum', color: '#c084fc' }
     ].filter(h => h.score >= 80);
 
     this.compatibilityHighlights = highlights.map(h => ({
@@ -722,10 +726,10 @@ export class MatchCelebrationComponent implements OnInit, OnDestroy {
     if (!this.showInsights) return;
 
     const insights = [
-      { icon: '🌟', text: 'You both value deep, meaningful conversations over small talk' },
-      { icon: '🎭', text: 'Similar sense of humor creates natural chemistry' },
-      { icon: '🌱', text: 'Shared growth mindset suggests lasting compatibility' },
-      { icon: '💫', text: 'Both prioritize authenticity in relationships' }
+      { icon: 'stars', text: 'You both value deep, meaningful conversations over small talk' },
+      { icon: 'theater_comedy', text: 'Similar sense of humor creates natural chemistry' },
+      { icon: 'eco', text: 'Shared growth mindset suggests lasting compatibility' },
+      { icon: 'auto_awesome', text: 'Both prioritize authenticity in relationships' }
     ];
 
     // Select 2-3 random insights

--- a/angular-frontend/src/app/shared/components/mood-selector/mood-selector.component.ts
+++ b/angular-frontend/src/app/shared/components/mood-selector/mood-selector.component.ts
@@ -48,7 +48,7 @@ import { HapticFeedbackService } from '@core/services/haptic-feedback.service';
             [style.box-shadow]="getCurrentMoodGlow()"
             [@orbPulse]="'pulse'">
           </div>
-          <span class="mood-icon">{{ getMoodIcon(currentMood) }}</span>
+          <mat-icon class="mood-icon">{{ getMoodIcon(currentMood) }}</mat-icon>
         </div>
 
         <div class="mood-info">
@@ -117,7 +117,7 @@ import { HapticFeedbackService } from '@core/services/haptic-feedback.service';
             <!-- Mood Details -->
             <div class="mood-details">
               <div class="mood-header">
-                <span class="mood-emoji">{{ getMoodIcon(mood) }}</span>
+                <mat-icon class="mood-emoji">{{ getMoodIcon(mood) }}</mat-icon>
                 <span class="mood-name">{{ mood.name }}</span>
               </div>
               <span class="mood-intensity">{{ mood.intensity }}</span>
@@ -456,7 +456,7 @@ import { HapticFeedbackService } from '@core/services/haptic-feedback.service';
       margin-bottom: 0.25rem;
 
       &:before {
-        content: '✓ ';
+        content: '\2713 ';
         color: var(--primary-color);
         font-weight: bold;
       }
@@ -756,13 +756,13 @@ export class MoodSelectorComponent implements OnInit, OnDestroy {
 
   getMoodIcon(mood: MoodState): string {
     const iconMap: { [key: string]: string } = {
-      contemplative: '🧘',
-      romantic: '💕',
-      energetic: '⚡',
-      peaceful: '🌿',
-      sophisticated: '🎭'
+      contemplative: 'self_improvement',
+      romantic: 'favorite',
+      energetic: 'bolt',
+      peaceful: 'eco',
+      sophisticated: 'theater_comedy'
     };
-    return iconMap[mood.id] || '✨';
+    return iconMap[mood.id] || 'auto_awesome';
   }
 
   getCurrentMoodGlow(): string {

--- a/angular-frontend/src/app/shared/components/navigation/navigation-demo.component.ts
+++ b/angular-frontend/src/app/shared/components/navigation/navigation-demo.component.ts
@@ -26,9 +26,9 @@ import { MatchCelebrationComponent } from '../match-celebration/match-celebratio
           <h2>Updated Navigation</h2>
           <p>Navigation now has 3 main sections instead of 5:</p>
           <ul>
-            <li>🔍 Discover</li>
-            <li>💬 Conversations (merged Connections + Messages with notification badge)</li>
-            <li>✨ Revelations</li>
+            <li>Discover</li>
+            <li>Conversations (merged Connections + Messages with notification badge)</li>
+            <li>Revelations</li>
           </ul>
           <p>Improved mobile typography with larger touch targets (min 44px) and better font sizes.</p>
         </section>
@@ -76,7 +76,7 @@ import { MatchCelebrationComponent } from '../match-celebration/match-celebratio
         </section>
 
         <section class="demo-section">
-          <h2>🌟 Enhanced Soul Visualizations</h2>
+          <h2>Enhanced Soul Visualizations</h2>
           <p>Revolutionary soul connection graphics that replace basic emojis with sophisticated animations.</p>
 
           <h3>Soul Orbs</h3>
@@ -114,13 +114,13 @@ import { MatchCelebrationComponent } from '../match-celebration/match-celebratio
               [connectionState]="'strong-match'"
               [orbSize]="'medium'"
               [showCompatibility]="true"
-              [statusMessage]="'Soul connection established ✨'">
+              [statusMessage]="'Soul connection established'">
             </app-soul-connection>
           </div>
         </section>
 
         <section class="demo-section">
-          <h2>📊 Compatibility Analysis</h2>
+          <h2>Compatibility Analysis</h2>
           <p>Advanced radar visualization showing multi-dimensional soul compatibility.</p>
 
           <div class="compatibility-demo">
@@ -136,14 +136,14 @@ import { MatchCelebrationComponent } from '../match-celebration/match-celebratio
         </section>
 
         <section class="demo-section">
-          <h2>🎉 Match Celebration</h2>
+          <h2>Match Celebration</h2>
           <p>Immersive celebration experience for successful soul connections.</p>
 
           <div class="celebration-demo">
             <button
               class="demo-button celebration-trigger"
               (click)="showCelebration = true">
-              ✨ Trigger Soul Match Celebration
+              Trigger Soul Match Celebration
             </button>
 
             <app-match-celebration

--- a/angular-frontend/src/app/shared/components/navigation/navigation.component.ts
+++ b/angular-frontend/src/app/shared/components/navigation/navigation.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Router, RouterModule } from '@angular/router';
+import { MatIconModule } from '@angular/material/icon';
 import { AuthService } from '../../../core/services/auth.service';
 import { NotificationService } from '../../../core/services/notification.service';
 import { Observable } from 'rxjs';
@@ -8,7 +9,7 @@ import { Observable } from 'rxjs';
 @Component({
   selector: 'app-navigation',
   standalone: true,
-  imports: [CommonModule, RouterModule],
+  imports: [CommonModule, RouterModule, MatIconModule],
   template: `
     <nav
       class="main-navigation"
@@ -21,7 +22,7 @@ import { Observable } from 'rxjs';
             routerLink="/"
             class="brand-link"
             aria-label="Dinner First home page">
-            <span class="brand-icon" aria-hidden="true">💫</span>
+            <mat-icon class="brand-icon" aria-hidden="true">local_dining</mat-icon>
             <span class="brand-text">Dinner First</span>
           </a>
         </div>
@@ -43,7 +44,7 @@ import { Observable } from 'rxjs';
             (keydown.enter)="closeMobileMenu()"
             (keydown.space)="closeMobileMenu()"
           >
-            <span class="nav-icon" aria-hidden="true">🔍</span>
+            <mat-icon class="nav-icon" aria-hidden="true">explore</mat-icon>
             <span class="nav-text">Discover</span>
           </a>
 
@@ -58,7 +59,7 @@ import { Observable } from 'rxjs';
             (keydown.enter)="closeMobileMenu()"
             (keydown.space)="closeMobileMenu()"
           >
-            <span class="nav-icon" aria-hidden="true">💬</span>
+            <mat-icon class="nav-icon" aria-hidden="true">forum</mat-icon>
             <span class="nav-text">Conversations</span>
             <span
               class="notification-badge"
@@ -80,7 +81,7 @@ import { Observable } from 'rxjs';
             (keydown.enter)="closeMobileMenu()"
             (keydown.space)="closeMobileMenu()"
           >
-            <span class="nav-icon" aria-hidden="true">✨</span>
+            <mat-icon class="nav-icon" aria-hidden="true">auto_awesome</mat-icon>
             <span class="nav-text">Revelations</span>
           </a>
 
@@ -119,7 +120,7 @@ import { Observable } from 'rxjs';
                 aria-label="View and edit your profile"
                 (click)="closeUserMenu()"
                 (keydown.enter)="closeUserMenu()">
-                <span aria-hidden="true">👤</span> Profile
+                <mat-icon aria-hidden="true">person</mat-icon> Profile
               </a>
               <a
                 routerLink="/settings"
@@ -129,7 +130,7 @@ import { Observable } from 'rxjs';
                 aria-label="Application settings and preferences"
                 (click)="closeUserMenu()"
                 (keydown.enter)="closeUserMenu()">
-                <span aria-hidden="true">⚙️</span> Settings
+                <mat-icon aria-hidden="true">settings</mat-icon> Settings
               </a>
               <div class="dropdown-divider" role="separator"></div>
               <button
@@ -139,7 +140,7 @@ import { Observable } from 'rxjs';
                 aria-label="Sign out of your account"
                 (click)="logout()"
                 (keydown.enter)="logout()">
-                <span aria-hidden="true">🚪</span> Logout
+                <mat-icon aria-hidden="true">logout</mat-icon> Logout
               </button>
             </div>
           </div>
@@ -209,7 +210,9 @@ import { Observable } from 'rxjs';
     }
 
     .brand-icon {
-      font-size: 1.5rem;
+      font-size: 24px;
+      width: 24px;
+      height: 24px;
     }
 
     .nav-menu {
@@ -242,7 +245,9 @@ import { Observable } from 'rxjs';
     }
 
     .nav-icon {
-      font-size: 1.2rem;
+      font-size: 20px;
+      width: 20px;
+      height: 20px;
     }
 
     .nav-text {
@@ -252,8 +257,8 @@ import { Observable } from 'rxjs';
 
     .revelation-link:hover,
     .revelation-link.active {
-      color: #ffd700;
-      background: rgba(255, 215, 0, 0.1);
+      color: var(--interactive-primary);
+      background: rgba(var(--primary-color-rgb), 0.1);
     }
 
     .nav-link {
@@ -338,6 +343,12 @@ import { Observable } from 'rxjs';
 
     .dropdown-item:hover {
       background: var(--surface-color);
+    }
+
+    .dropdown-item mat-icon {
+      font-size: 20px;
+      width: 20px;
+      height: 20px;
     }
 
     .logout-btn:hover {
@@ -425,7 +436,9 @@ import { Observable } from 'rxjs';
       }
 
       .nav-icon {
-        font-size: 1.5rem;
+        font-size: 24px;
+        width: 24px;
+        height: 24px;
         min-width: 24px;
       }
 
@@ -481,7 +494,7 @@ import { Observable } from 'rxjs';
       }
 
       .nav-icon {
-        font-size: 1.6rem;
+        font-size: 24px;
       }
     }
 

--- a/angular-frontend/src/app/shared/components/notification-toast/notification-toast.component.spec.ts
+++ b/angular-frontend/src/app/shared/components/notification-toast/notification-toast.component.spec.ts
@@ -141,7 +141,7 @@ describe('NotificationToastComponent', () => {
     {
       id: 'notif-4',
       type: 'photo_reveal_ready',
-      title: 'Photo Reveal Ready! 📸',
+      title: 'Photo Reveal Ready!',
       message: 'Both you and Emma are ready for photo reveal',
       priority: 'urgent',
       category: 'soul_connection',

--- a/angular-frontend/src/app/shared/components/onboarding-welcome/onboarding-welcome.component.ts
+++ b/angular-frontend/src/app/shared/components/onboarding-welcome/onboarding-welcome.component.ts
@@ -79,7 +79,7 @@ import { SoulOrbComponent } from '../soul-orb/soul-orb.component';
       <!-- Welcome Content -->
       <div class="welcome-content">
         <div id="welcome-description" class="philosophy-section">
-          <h2 class="section-title">✨ Our Philosophy</h2>
+          <h2 class="section-title">Our Philosophy</h2>
           <p class="philosophy-text">
             In a world obsessed with appearances, we believe the most beautiful connections
             happen when hearts recognize each other first. Here, your emotional depth,
@@ -89,7 +89,7 @@ import { SoulOrbComponent } from '../soul-orb/soul-orb.component';
 
         <!-- How It Works -->
         <div class="how-it-works">
-          <h2 class="section-title">💫 How Soul Connections Work</h2>
+          <h2 class="section-title">How Soul Connections Work</h2>
 
           <div class="steps-container">
             <div class="step" *ngFor="let step of howItWorksSteps; let i = index">
@@ -98,18 +98,18 @@ import { SoulOrbComponent } from '../soul-orb/soul-orb.component';
                 <h3 class="step-title">{{ step.title }}</h3>
                 <p class="step-description">{{ step.description }}</p>
               </div>
-              <div class="step-icon" [innerHTML]="step.icon"></div>
+              <div class="step-icon"><mat-icon>{{step.icon}}</mat-icon></div>
             </div>
           </div>
         </div>
 
         <!-- Benefits -->
         <div class="benefits-section">
-          <h2 class="section-title">💖 Why Soul-First Dating Works</h2>
+          <h2 class="section-title">Why Soul-First Dating Works</h2>
 
           <div class="benefits-grid">
             <div class="benefit" *ngFor="let benefit of benefits">
-              <div class="benefit-icon" [innerHTML]="benefit.icon"></div>
+              <div class="benefit-icon"><mat-icon>{{benefit.icon}}</mat-icon></div>
               <h3 class="benefit-title">{{ benefit.title }}</h3>
               <p class="benefit-description">{{ benefit.description }}</p>
             </div>
@@ -118,7 +118,7 @@ import { SoulOrbComponent } from '../soul-orb/soul-orb.component';
 
         <!-- Tutorial Options -->
         <div class="tutorial-options">
-          <h2 class="section-title">🎯 Choose Your Journey</h2>
+          <h2 class="section-title">Choose Your Journey</h2>
 
           <div class="option-cards">
             <div
@@ -131,7 +131,7 @@ import { SoulOrbComponent } from '../soul-orb/soul-orb.component';
               role="button"
               aria-label="Choose guided tutorial">
               <div class="option-header">
-                <div class="option-icon">🌟</div>
+                <div class="option-icon"><mat-icon>explore</mat-icon></div>
                 <h3 class="option-title">Guided Experience</h3>
               </div>
               <p class="option-description">
@@ -151,7 +151,7 @@ import { SoulOrbComponent } from '../soul-orb/soul-orb.component';
               role="button"
               aria-label="Choose quick start">
               <div class="option-header">
-                <div class="option-icon">🚀</div>
+                <div class="option-icon"><mat-icon>rocket_launch</mat-icon></div>
                 <h3 class="option-title">Quick Start</h3>
               </div>
               <p class="option-description">
@@ -214,7 +214,7 @@ import { SoulOrbComponent } from '../soul-orb/soul-orb.component';
       <!-- Footer -->
       <div class="welcome-footer">
         <p class="footer-text">
-          🌙 Welcome to a more meaningful way to connect. Your soul journey begins now.
+          Welcome to a more meaningful way to connect. Your soul journey begins now.
         </p>
       </div>
     </div>
@@ -703,22 +703,22 @@ export class OnboardingWelcomeComponent implements OnInit {
     {
       title: 'Share Your Soul',
       description: 'Complete your emotional profile with values, dreams, and what makes you unique.',
-      icon: '💖'
+      icon: 'favorite'
     },
     {
       title: 'Algorithm Magic',
       description: 'Our compatibility algorithm finds people who align with your deeper self.',
-      icon: '✨'
+      icon: 'auto_awesome'
     },
     {
       title: 'Connect First',
       description: 'Start meaningful conversations based on emotional compatibility.',
-      icon: '💬'
+      icon: 'forum'
     },
     {
       title: 'Reveal Photos',
       description: 'After connecting emotionally, choose when to share photos together.',
-      icon: '🌅'
+      icon: 'photo_camera'
     }
   ];
 
@@ -726,22 +726,22 @@ export class OnboardingWelcomeComponent implements OnInit {
     {
       title: 'Deeper Connections',
       description: 'Build relationships based on true compatibility, not just attraction.',
-      icon: '🔗'
+      icon: 'link'
     },
     {
       title: 'Authentic Self',
       description: 'Be valued for who you truly are, not just your appearance.',
-      icon: '🌟'
+      icon: 'star'
     },
     {
       title: 'Meaningful Conversations',
       description: 'Start with topics that matter and create genuine understanding.',
-      icon: '💭'
+      icon: 'chat_bubble'
     },
     {
       title: 'Quality Matches',
       description: 'Spend time with people who truly align with your values and goals.',
-      icon: '🎯'
+      icon: 'track_changes'
     }
   ];
 

--- a/angular-frontend/src/app/shared/components/soul-connection/soul-connection.component.ts
+++ b/angular-frontend/src/app/shared/components/soul-connection/soul-connection.component.ts
@@ -157,7 +157,7 @@ import { SoulConfig } from '../../models/soul-types';
               text-anchor="middle"
               class="connection-heart"
               [style.animation-delay]="heart.delay + 's'">
-              💖
+              &#x2665;
             </text>
           </g>
         </svg>

--- a/angular-frontend/src/app/shared/components/soul-typing-indicator.component.ts
+++ b/angular-frontend/src/app/shared/components/soul-typing-indicator.component.ts
@@ -4,6 +4,7 @@
  */
 import { Component, Input, OnInit, OnDestroy, ChangeDetectionStrategy, ElementRef, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { MatIconModule } from '@angular/material/icon';
 import { Subject, interval, takeUntil } from 'rxjs';
 import { TypingUser } from '../../core/services/chat.service';
 
@@ -22,7 +23,7 @@ export interface SoulTypingConfig {
 @Component({
   selector: 'app-soul-typing-indicator',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, MatIconModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div
@@ -60,7 +61,7 @@ export interface SoulTypingConfig {
 
           <!-- Connection stage indicator -->
           <div class="stage-indicator" [attr.data-stage]="config.connectionStage">
-            {{ getStageEmoji() }}
+            <mat-icon>{{ getStageEmoji() }}</mat-icon>
           </div>
         </div>
 
@@ -80,7 +81,7 @@ export interface SoulTypingConfig {
         <div class="emotional-context" [attr.data-emotion]="config.emotionalState">
           <span class="context-text">{{ getEmotionalMessage() }}</span>
           <div class="compatibility-indicator" *ngIf="config.compatibilityScore >= 70">
-            <span class="compatibility-glow">{{ config.compatibilityScore }}% ✨</span>
+            <span class="compatibility-glow">{{ config.compatibilityScore }}%</span>
           </div>
         </div>
       </div>
@@ -519,10 +520,10 @@ export class SoulTypingIndicatorComponent implements OnInit, OnDestroy {
 
   getStageEmoji(): string {
     const stageEmojis = {
-      soul_discovery: '🔍',
-      revelation_sharing: '✨',
-      photo_reveal: '📸',
-      deeper_connection: '💫'
+      soul_discovery: 'search',
+      revelation_sharing: 'auto_awesome',
+      photo_reveal: 'photo_camera',
+      deeper_connection: 'stars'
     };
 
     return stageEmojis[this.config.connectionStage];

--- a/angular-frontend/src/app/shared/components/typing-indicator/typing-indicator.component.spec.ts
+++ b/angular-frontend/src/app/shared/components/typing-indicator/typing-indicator.component.spec.ts
@@ -136,7 +136,7 @@ describe('TypingIndicatorComponent', () => {
 
   it('should generate typing ellipsis', () => {
     const ellipsis = component.getTypingEllipsis();
-    expect(ellipsis).toMatch(/✧+/);
+    expect(ellipsis).toMatch(/\.+/);
   });
 
   it('should detect connection energy based on stage', () => {

--- a/angular-frontend/src/app/shared/components/typing-indicator/typing-indicator.component.ts
+++ b/angular-frontend/src/app/shared/components/typing-indicator/typing-indicator.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input, OnInit, OnDestroy, OnChanges } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { MatIconModule } from '@angular/material/icon';
 import { trigger, state, style, animate, transition, keyframes } from '@angular/animations';
 import { Subscription, timer } from 'rxjs';
 import { takeWhile } from 'rxjs/operators';
@@ -16,7 +17,7 @@ export interface TypingUser {
 @Component({
   selector: 'app-typing-indicator',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, MatIconModule],
   template: `
     <div
       class="typing-indicator"
@@ -63,13 +64,13 @@ export interface TypingUser {
           <span class="typing-label">{{ getSoulTypingText() }}</span>
           <span class="typing-ellipsis" [@ellipsisAnimation]="'animate'">{{ getTypingEllipsis() }}</span>
           <div class="connection-energy" *ngIf="showConnectionEnergy()" [@energyPulse]="'pulse'">
-            ✨
+            <mat-icon>auto_awesome</mat-icon>
           </div>
         </div>
 
         <!-- Emotional State Indicator -->
         <div class="emotional-state" *ngIf="getEmotionalState()" [@emotionalGlow]="'glow'">
-          <span class="state-emoji">{{ getEmotionalEmoji() }}</span>
+          <mat-icon class="state-emoji">{{ getEmotionalEmoji() }}</mat-icon>
           <span class="state-label">{{ getEmotionalState() }}</span>
         </div>
       </div>
@@ -551,7 +552,7 @@ export class TypingIndicatorComponent implements OnInit, OnDestroy, OnChanges {
   }
 
   getTypingEllipsis(): string {
-    const stages = ['✧', '✧✧', '✧✧✧'];
+    const stages = ['.', '..', '...'];
     const currentStage = Math.floor(Date.now() / 500) % stages.length;
     return stages[currentStage];
   }
@@ -587,14 +588,14 @@ export class TypingIndicatorComponent implements OnInit, OnDestroy, OnChanges {
     if (!user.emotionalState) return '';
 
     const emojiMap = {
-      contemplative: '🧘',
-      romantic: '💕',
-      energetic: '⚡',
-      peaceful: '🌿',
-      sophisticated: '🎭'
+      contemplative: 'self_improvement',
+      romantic: 'favorite',
+      energetic: 'bolt',
+      peaceful: 'eco',
+      sophisticated: 'theater_comedy'
     };
 
-    return emojiMap[user.emotionalState] || '✨';
+    return emojiMap[user.emotionalState] || 'auto_awesome';
   }
 
   getAriaLabel(): string {

--- a/angular-frontend/src/app/shared/components/websocket-status/websocket-status.component.ts
+++ b/angular-frontend/src/app/shared/components/websocket-status/websocket-status.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit, OnDestroy, Input } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { MatIconModule } from '@angular/material/icon';
 import { Observable, Subject, combineLatest } from 'rxjs';
 import { map, takeUntil } from 'rxjs/operators';
 import { WebSocketPoolService } from '../../../core/services/websocket-pool.service';
@@ -16,7 +17,7 @@ export interface ConnectionStatusInfo {
 @Component({
   selector: 'app-websocket-status',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, MatIconModule],
   template: `
     <div
       class="websocket-status"
@@ -46,7 +47,7 @@ export interface ConnectionStatusInfo {
         </span>
         <span class="metric-item">
           <span class="metric-value">{{statusInfo.onlineUsers}}</span>
-          <span class="metric-label">👥</span>
+          <span class="metric-label"><mat-icon>people</mat-icon></span>
         </span>
       </div>
     </div>

--- a/angular-frontend/src/index.html
+++ b/angular-frontend/src/index.html
@@ -6,7 +6,7 @@
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
-  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>
 <body class="mat-typography">

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,63 @@
+services:
+
+  postgres:
+    image: postgres:15-alpine
+    container_name: dinner-first-postgres-dev
+    environment:
+      POSTGRES_DB: dinner_first
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_dev_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  backend:
+    build:
+      context: ./python-backend
+      dockerfile: Dockerfile.dev
+    container_name: dinner-first-backend-dev
+    environment:
+      DATABASE_URL: postgresql://postgres:postgres@postgres:5432/dinner_first
+      DB_HOST: postgres
+      DB_USER: postgres
+      SECRET_KEY: dev_secret_key_min_32_characters_here_change_in_prod
+      JWT_ALGORITHM: HS256
+      ACCESS_TOKEN_EXPIRE_MINUTES: 1440
+      CORS_ORIGINS: "http://localhost:4200,http://localhost:5001"
+      ENVIRONMENT: development
+      DEBUG: "true"
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./python-backend:/app
+      - backend_dev_cache:/root/.cache
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  frontend:
+    build:
+      context: ./angular-frontend
+      dockerfile: Dockerfile.dev
+    container_name: dinner-first-frontend-dev
+    ports:
+      - "4200:4200"
+    volumes:
+      - ./angular-frontend/src:/app/src
+      - ./angular-frontend/angular.json:/app/angular.json
+      - ./angular-frontend/tsconfig.json:/app/tsconfig.json:ro
+      - ./angular-frontend/tsconfig.app.json:/app/tsconfig.app.json:ro
+    environment:
+      - CHOKIDAR_USEPOLLING=true
+    depends_on:
+      - backend
+
+volumes:
+  postgres_dev_data:
+  backend_dev_cache:

--- a/python-backend/Dockerfile.dev
+++ b/python-backend/Dockerfile.dev
@@ -1,0 +1,23 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PYTHONPATH="/app"
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y \
+    libpq-dev \
+    build-essential \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY entrypoint.dev.sh /entrypoint.dev.sh
+RUN chmod +x /entrypoint.dev.sh
+
+EXPOSE 8000
+
+ENTRYPOINT ["/entrypoint.dev.sh"]

--- a/python-backend/entrypoint.dev.sh
+++ b/python-backend/entrypoint.dev.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+set -e
+
+DB_HOST="${DB_HOST:-postgres}"
+DB_USER="${DB_USER:-postgres}"
+
+echo "Waiting for PostgreSQL at $DB_HOST:5432..."
+until python -c "
+import socket, sys
+try:
+    s = socket.create_connection(('$DB_HOST', 5432), timeout=2)
+    s.close()
+    sys.exit(0)
+except Exception:
+    sys.exit(1)
+" 2>/dev/null; do
+  sleep 1
+done
+echo "PostgreSQL is ready."
+
+echo "Running database migrations..."
+alembic upgrade head
+
+echo "Starting FastAPI development server..."
+exec uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload

--- a/start-app.sh
+++ b/start-app.sh
@@ -1,382 +1,42 @@
 #!/bin/bash
+# Dinner First — Docker development startup
 
-# Dinner First Application Startup Script
-# Starts PostgreSQL database, Python backend, and Angular frontend
-
-set -e  # Exit on any error
+set -e
 
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-BACKEND_DIR="$PROJECT_ROOT/python-backend"
-FRONTEND_DIR="$PROJECT_ROOT/angular-frontend"
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m' # No Color
+if ! docker info > /dev/null 2>&1; then
+  echo "Docker is not running. Please start Docker Desktop and try again."
+  exit 1
+fi
 
-# Logging function
-log() {
-    echo -e "${BLUE}[$(date +'%Y-%m-%d %H:%M:%S')] $1${NC}"
-}
-
-error() {
-    echo -e "${RED}[ERROR] $1${NC}"
-}
-
-success() {
-    echo -e "${GREEN}[SUCCESS] $1${NC}"
-}
-
-warning() {
-    echo -e "${YELLOW}[WARNING] $1${NC}"
-}
-
-# Check if Docker is running
-check_docker() {
-    if ! docker info > /dev/null 2>&1; then
-        error "Docker is not running. Please start Docker and try again."
-        exit 1
-    fi
-    success "Docker is running"
-}
-
-# Start PostgreSQL database in Docker
-start_database() {
-    log "Starting PostgreSQL database..."
-
-    # Check if container already exists
-    if docker ps -a --format 'table {{.Names}}' | grep -q "dinner_first-postgres"; then
-        log "PostgreSQL container already exists. Starting it..."
-        docker start dinner_first-postgres
-    else
-        log "Creating new PostgreSQL container..."
-        docker run -d \
-            --name dinner_first-postgres \
-            -e POSTGRES_DB=dinner_first \
-            -e POSTGRES_USER=postgres \
-            -e POSTGRES_PASSWORD=postgres \
-            -p 5432:5432 \
-            postgres:15
-    fi
-
-    # Wait for database to be ready
-    log "Waiting for database to be ready..."
-    sleep 5
-
-    # Test database connection
-    for i in {1..30}; do
-        if docker exec dinner_first-postgres pg_isready -U postgres > /dev/null 2>&1; then
-            success "PostgreSQL is ready"
-            break
-        fi
-        if [ $i -eq 30 ]; then
-            error "Database failed to start after 30 seconds"
-            exit 1
-        fi
-        sleep 1
-    done
-}
-
-# Start Python backend
-start_backend() {
-    log "Starting Python backend..."
-
-    cd "$BACKEND_DIR"
-
-    # Check if virtual environment exists
-    if [ ! -d "venv" ]; then
-        warning "Virtual environment not found. Creating it..."
-        python3 -m venv venv
-    fi
-
-    # Activate virtual environment and install dependencies
-    source venv/bin/activate
-
-    log "Installing Python dependencies..."
-    pip install -r requirements.txt > /dev/null 2>&1
-
-    # Handle database migrations with error handling
-    log "Running database migrations..."
-
-    # Check for multiple heads and merge if necessary
-    if alembic heads 2>/dev/null | wc -l | grep -q "2"; then
-        warning "Multiple migration heads detected. Merging..."
-        alembic merge heads -m "Auto-merge migration heads" 2>/dev/null || true
-    fi
-
-    # Run migrations with retry logic
-    for i in {1..3}; do
-        if alembic upgrade head 2>/dev/null; then
-            success "Database migrations completed"
-            break
-        elif [ $i -eq 3 ]; then
-            warning "Migration failed, but continuing with startup..."
-            break
-        else
-            warning "Migration attempt $i failed, retrying..."
-            sleep 2
-        fi
-    done
-
-    # Start the backend server in background
-    log "Starting FastAPI server on port 5000..."
-    nohup python run.py > backend.log 2>&1 &
-    BACKEND_PID=$!
-    echo $BACKEND_PID > backend.pid
-
-    # Wait for backend to start
-    sleep 5
-
-    # Test backend health with extended timeout
-    for i in {1..60}; do
-        if curl -s http://localhost:5000/health > /dev/null 2>&1; then
-            success "Backend is running on http://localhost:5000"
-            break
-        elif curl -s http://localhost:5000/docs > /dev/null 2>&1; then
-            success "Backend is running on http://localhost:5000 (docs available)"
-            break
-        fi
-        if [ $i -eq 60 ]; then
-            warning "Backend health check failed, but process may still be starting"
-            log "Check backend.log for details: tail -f $BACKEND_DIR/backend.log"
-        fi
-        sleep 1
-    done
-}
-
-# Start observability stack
-start_observability() {
-    log "Starting observability stack (Grafana, Loki, Prometheus)..."
-
-    MONITORING_DIR="$PROJECT_ROOT/monitoring/loki"
-
-    if [ -d "$MONITORING_DIR" ]; then
-        cd "$MONITORING_DIR"
-
-        # Check if observability stack is already running
-        if docker-compose -f docker-compose.loki.yml ps | grep -q "Up"; then
-            log "Observability stack already running"
-        else
-            log "Starting Loki, Grafana, Prometheus, and Alertmanager..."
-            docker-compose -f docker-compose.loki.yml up -d
-
-            # Wait for services to be ready
-            sleep 15
-
-            # Health checks for observability services
-            for i in {1..30}; do
-                if curl -s http://localhost:3000/api/health > /dev/null 2>&1; then
-                    success "Grafana is ready on http://localhost:3000"
-                    break
-                fi
-                if [ $i -eq 30 ]; then
-                    warning "Grafana health check timeout, but may still be starting"
-                fi
-                sleep 1
-            done
-
-            for i in {1..30}; do
-                if curl -s http://localhost:9090/-/ready > /dev/null 2>&1; then
-                    success "Prometheus is ready on http://localhost:9090"
-                    break
-                fi
-                if [ $i -eq 30 ]; then
-                    warning "Prometheus health check timeout, but may still be starting"
-                fi
-                sleep 1
-            done
-
-            for i in {1..30}; do
-                if curl -s http://localhost:3100/ready > /dev/null 2>&1; then
-                    success "Loki is ready on http://localhost:3100"
-                    break
-                fi
-                if [ $i -eq 30 ]; then
-                    warning "Loki health check timeout, but may still be starting"
-                fi
-                sleep 1
-            done
-        fi
-    else
-        warning "Observability stack not found at $MONITORING_DIR - skipping"
-    fi
-}
-
-# Start Angular frontend
-start_frontend() {
-    log "Starting Angular frontend..."
-
-    cd "$FRONTEND_DIR"
-
-    # Install dependencies if node_modules doesn't exist
-    if [ ! -d "node_modules" ]; then
-        log "Installing Angular dependencies..."
-        npm install
-    fi
-
-    # Start the frontend server in background
-    log "Starting Angular development server on port 5001..."
-    nohup npm run start > frontend.log 2>&1 &
-    FRONTEND_PID=$!
-    echo $FRONTEND_PID > frontend.pid
-
-    # Wait for frontend to start
-    sleep 10
-
-    # Test frontend
-    for i in {1..60}; do
-        if curl -s http://localhost:5001 > /dev/null; then
-            success "Frontend is running on http://localhost:5001"
-            break
-        fi
-        if [ $i -eq 60 ]; then
-            error "Frontend failed to start after 60 seconds"
-            exit 1
-        fi
-        sleep 1
-    done
-}
-
-# Cleanup function
-cleanup() {
-    log "Shutting down services..."
-
-    # Kill backend
-    if [ -f "$BACKEND_DIR/backend.pid" ]; then
-        BACKEND_PID=$(cat "$BACKEND_DIR/backend.pid")
-        if ps -p $BACKEND_PID > /dev/null; then
-            kill $BACKEND_PID
-            rm "$BACKEND_DIR/backend.pid"
-            success "Backend stopped"
-        fi
-    fi
-
-    # Kill frontend
-    if [ -f "$FRONTEND_DIR/frontend.pid" ]; then
-        FRONTEND_PID=$(cat "$FRONTEND_DIR/frontend.pid")
-        if ps -p $FRONTEND_PID > /dev/null; then
-            kill $FRONTEND_PID
-            rm "$FRONTEND_DIR/frontend.pid"
-            success "Frontend stopped"
-        fi
-    fi
-
-    # Stop observability stack
-    MONITORING_DIR="$PROJECT_ROOT/monitoring/loki"
-    if [ -d "$MONITORING_DIR" ]; then
-        cd "$MONITORING_DIR"
-        if docker-compose -f docker-compose.loki.yml ps | grep -q "Up"; then
-            log "Stopping observability stack..."
-            docker-compose -f docker-compose.loki.yml down
-            success "Observability stack stopped"
-        fi
-    fi
-
-    # Stop database container
-    if docker ps --format 'table {{.Names}}' | grep -q "dinner_first-postgres"; then
-        docker stop dinner_first-postgres
-        success "Database stopped"
-    fi
-
-    log "All services stopped"
-}
-
-# Trap cleanup on script exit
-trap cleanup EXIT
-
-# Main execution
-main() {
-    log "Starting Dinner First Application with Full Observability Stack..."
-
-    check_docker
-    start_database
-    start_observability
-    start_backend
-    start_frontend
-
-    success "All services are running!"
-    echo ""
-    echo "🚀 Application URLs:"
-    echo "   Frontend: http://localhost:5001"
-    echo "   Backend API: http://localhost:5000"
-    echo "   API Docs: http://localhost:5000/docs"
-    echo "   Database: localhost:5432 (dinner_first)"
-    echo ""
-    echo "📊 Observability Stack:"
-    echo "   Grafana Dashboard: http://localhost:3000 (admin/admin123)"
-    echo "   Prometheus Metrics: http://localhost:9090"
-    echo "   Loki Logs: http://localhost:3100"
-    echo "   Alertmanager: http://localhost:9093"
-    echo ""
-    echo "📝 Application Logs:"
-    echo "   Backend: $BACKEND_DIR/backend.log"
-    echo "   Frontend: $FRONTEND_DIR/frontend.log"
-    echo ""
-    echo "🔍 SRE Features:"
-    echo "   - Real-time metrics correlation"
-    echo "   - Soul connection monitoring"
-    echo "   - A/B testing analytics"
-    echo "   - Security alert monitoring"
-    echo "   - Business KPI tracking"
-    echo ""
-    echo "Press Ctrl+C to stop all services"
-
-    # Keep script running
-    while true; do
-        sleep 1
-    done
-}
-
-# Handle command line arguments
-case "${1:-}" in
-    "stop")
-        cleanup
-        exit 0
-        ;;
-    "logs")
-        if [ -f "$BACKEND_DIR/backend.log" ]; then
-            echo "=== Backend Logs ==="
-            tail -f "$BACKEND_DIR/backend.log" &
-        fi
-        if [ -f "$FRONTEND_DIR/frontend.log" ]; then
-            echo "=== Frontend Logs ==="
-            tail -f "$FRONTEND_DIR/frontend.log" &
-        fi
-        wait
-        ;;
-    "observability")
-        check_docker
-        start_observability
-        echo ""
-        echo "📊 Observability stack started!"
-        echo "   Grafana: http://localhost:3000 (admin/admin123)"
-        echo "   Prometheus: http://localhost:9090"
-        echo "   Loki: http://localhost:3100"
-        echo "   Alertmanager: http://localhost:9093"
-        ;;
-    "monitoring")
-        # Alias for observability
-        check_docker
-        start_observability
-        echo ""
-        echo "📊 Monitoring stack started!"
-        echo "   Grafana: http://localhost:3000 (admin/admin123)"
-        echo "   Prometheus: http://localhost:9090"
-        echo "   Loki: http://localhost:3100"
-        echo "   Alertmanager: http://localhost:9093"
-        ;;
-    "")
-        main
-        ;;
-    *)
-        echo "Usage: $0 [stop|logs|observability|monitoring]"
-        echo "  (no args)     - Start all services with full observability"
-        echo "  stop          - Stop all services"
-        echo "  logs          - Show application logs"
-        echo "  observability - Start only observability stack (Grafana, Loki, Prometheus)"
-        echo "  monitoring    - Alias for observability"
-        exit 1
-        ;;
+case "${1:-up}" in
+  up)
+    echo "Starting Dinner First (Docker dev stack)..."
+    docker compose -f "$PROJECT_ROOT/docker-compose.dev.yml" up --build
+    ;;
+  down)
+    echo "Stopping all services..."
+    docker compose -f "$PROJECT_ROOT/docker-compose.dev.yml" down
+    ;;
+  logs)
+    docker compose -f "$PROJECT_ROOT/docker-compose.dev.yml" logs -f "${2:-}"
+    ;;
+  ps)
+    docker compose -f "$PROJECT_ROOT/docker-compose.dev.yml" ps
+    ;;
+  reset)
+    echo "Stopping services and removing volumes (database data will be deleted)..."
+    docker compose -f "$PROJECT_ROOT/docker-compose.dev.yml" down -v
+    ;;
+  *)
+    echo "Usage: $0 [up|down|logs [service]|ps|reset]"
+    echo "  up           Start all services (default)"
+    echo "  down         Stop all services"
+    echo "  logs         Tail logs for all services"
+    echo "  logs backend Tail logs for a specific service"
+    echo "  ps           Show service status"
+    echo "  reset        Stop and remove all volumes (wipes database)"
+    exit 1
+    ;;
 esac


### PR DESCRIPTION
## Summary

- **Docker-only dev stack**: `docker-compose.dev.yml` orchestrates postgres + backend + frontend with healthchecks, hot-reload volumes, and a Python socket-based wait-for-DB entrypoint. `start-app.sh` is now a thin wrapper around compose commands (up/down/logs/ps/reset).
- **UI/UX polish**: Replaced ~210 emoji instances across 40+ components with Angular Material Icons for a more premium, cohesive visual language. Preserves intentional emoji features (messaging reactions/picker).
- **Theme fix**: Removed duplicate `rose-red.css` Material theme (conflicted with `pink-bluegrey.css`) and added Roboto 700 weight to Google Fonts.

## Changes

### Infrastructure
- `docker-compose.dev.yml` — new dev orchestration file
- `python-backend/Dockerfile.dev` + `entrypoint.dev.sh` — Python socket-based wait for postgres (pg_isready not bundled in slim image)
- `angular-frontend/Dockerfile.dev` — node:18-alpine with polling enabled for Docker bind mounts
- `start-app.sh` — rewritten as compose wrapper
- `CLAUDE.md` — updated dev command docs

### UI/UX (emoji → Material Icons)
- Navigation (7 icons), landing page (hero + features), revelations (16), match-celebration (19), onboarding welcome (14), notifications service + component, discover CSS pseudo-elements
- Comprehensive sweep across 35 additional files: empty states, settings, loading screens, compatibility radar, etc.
- Messaging emoji picker/reactions: **intentionally preserved** (core feature)

## Test Plan

- [x] Frontend build passes clean
- [x] Plan's 27 new tests pass
- [x] Pre-existing test failures (49) verified unchanged from base SHA
- [ ] Verify Docker stack boots clean on fresh checkout (`./start-app.sh up`)
- [ ] Visual QA: navigation, landing, discover, onboarding, match celebration, notifications
- [ ] Confirm messaging emoji features still functional