### PR TITLE
fix(messaging): align messages router/service with real Message schema

### DIFF
--- a/python-backend/app/api/v1/routers/chat.py
+++ b/python-backend/app/api/v1/routers/chat.py
@@ -214,7 +214,7 @@ def get_conversations(
             .filter(
                 Message.connection_id == connection.id,
                 Message.sender_id != current_user.id,
-                Message.is_read is False,
+                Message.is_read.is_(False),
             )
             .count()
         )

--- a/python-backend/app/api/v1/routers/messages.py
+++ b/python-backend/app/api/v1/routers/messages.py
@@ -46,12 +46,10 @@ class ConversationMessage(BaseModel):
     id: int
     sender_id: int
     content: str
-    emotional_state: str
-    message_energy: str
+    message_type: str
     is_soul_revelation: bool
     is_read: bool
     created_at: str
-    read_at: Optional[str]
     is_own_message: bool
 
 
@@ -287,7 +285,7 @@ async def get_message_statistics(
             .filter(
                 Message.connection_id.in_(connection_ids),
                 Message.sender_id != current_user.id,
-                Message.is_read is False,
+                Message.is_read.is_(False),
             )
             .count()
             if connection_ids
@@ -299,13 +297,12 @@ async def get_message_statistics(
             [c for c in user_connections if c.status == "active"]
         )
 
-        # Get most used emotional states
-        emotional_states = (
-            db.query(Message.emotional_state, func.count(Message.id).label("count"))
+        # Message type distribution (text / revelation / photo / system)
+        message_type_counts = (
+            db.query(Message.message_type, func.count(Message.id).label("count"))
             .filter(Message.sender_id == current_user.id)
-            .group_by(Message.emotional_state)
+            .group_by(Message.message_type)
             .order_by(func.count(Message.id).desc())
-            .limit(5)
             .all()
         )
 
@@ -321,9 +318,9 @@ async def get_message_statistics(
                     "active": active_conversations,
                     "total": len(user_connections),
                 },
-                "emotional_patterns": [
-                    {"state": state, "count": count}
-                    for state, count in emotional_states
+                "message_types": [
+                    {"type": mtype, "count": count}
+                    for mtype, count in message_type_counts
                 ],
             },
             "generated_at": datetime.utcnow().isoformat(),
@@ -475,9 +472,9 @@ async def search_messages(
 
             base_query = base_query.filter(Message.connection_id == connection_id)
 
-        # Search in message content (case-insensitive)
+        # Search in message text (case-insensitive)
         search_results = (
-            base_query.filter(Message.content.ilike(f"%{query}%"))
+            base_query.filter(Message.message_text.ilike(f"%{query}%"))
             .order_by(Message.created_at.desc())
             .limit(limit)
             .all()
@@ -502,8 +499,8 @@ async def search_messages(
                         ),
                         "is_current_user": message.sender_id == current_user.id,
                     },
-                    "content": message.content,
-                    "emotional_state": message.emotional_state,
+                    "content": message.message_text,
+                    "message_type": message.message_type,
                     "created_at": message.created_at.isoformat(),
                 }
             )
@@ -524,32 +521,3 @@ async def search_messages(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to search messages",
         )
-
-    def _get_match_context(
-        self, content: str, query: str, context_chars: int = 50
-    ) -> str:
-        """Get context around search match"""
-        try:
-            query_lower = query.lower()
-            content_lower = content.lower()
-
-            start_idx = content_lower.find(query_lower)
-            if start_idx == -1:
-                return content[:100] + "..." if len(content) > 100 else content
-
-            # Get context around the match
-            context_start = max(0, start_idx - context_chars)
-            context_end = min(len(content), start_idx + len(query) + context_chars)
-
-            context = content[context_start:context_end]
-
-            # Add ellipsis if truncated
-            if context_start > 0:
-                context = "..." + context
-            if context_end < len(content):
-                context = context + "..."
-
-            return context
-
-        except Exception:
-            return content[:100] + "..." if len(content) > 100 else content

--- a/python-backend/app/services/message_service.py
+++ b/python-backend/app/services/message_service.py
@@ -119,30 +119,18 @@ class MessageService:
                     error="rate_limited",
                 )
 
-            # Get sender info for emotional context
+            # Get sender info
             sender = db.query(User).filter(User.id == sender_id).first()
             partner_id = connection.get_partner_id(sender_id)
 
-            # Create message with emotional context
+            is_revelation = bool(
+                emotional_context and emotional_context.get("is_revelation", False)
+            )
             message = Message(
                 connection_id=connection_id,
                 sender_id=sender_id,
-                content=content.strip(),
-                emotional_state=(
-                    emotional_context.get("emotional_state")
-                    if emotional_context
-                    else sender.current_emotional_state
-                ),
-                message_energy=(
-                    emotional_context.get("message_energy", "medium")
-                    if emotional_context
-                    else "medium"
-                ),
-                is_soul_revelation=(
-                    emotional_context.get("is_revelation", False)
-                    if emotional_context
-                    else False
-                ),
+                message_text=content.strip(),
+                message_type="revelation" if is_revelation else "text",
             )
 
             db.add(message)
@@ -172,8 +160,7 @@ class MessageService:
                     "connection_id": connection_id,
                     "partner_id": partner_id,
                     "message_length": len(content),
-                    "emotional_state": message.emotional_state,
-                    "is_revelation": message.is_soul_revelation,
+                    "is_revelation": is_revelation,
                     "delivered": delivery_success,
                 },
                 db=db,
@@ -249,7 +236,6 @@ class MessageService:
             ]
             for message in unread_messages:
                 message.is_read = True
-                message.read_at = datetime.utcnow()
 
             if unread_messages:
                 db.commit()
@@ -265,15 +251,11 @@ class MessageService:
                     {
                         "id": message.id,
                         "sender_id": message.sender_id,
-                        "content": message.content,
-                        "emotional_state": message.emotional_state,
-                        "message_energy": message.message_energy,
-                        "is_soul_revelation": message.is_soul_revelation,
+                        "content": message.message_text,
+                        "message_type": message.message_type,
+                        "is_soul_revelation": message.message_type == "revelation",
                         "is_read": message.is_read,
                         "created_at": message.created_at.isoformat(),
-                        "read_at": (
-                            message.read_at.isoformat() if message.read_at else None
-                        ),
                         "is_own_message": message.sender_id == user_id,
                     }
                 )
@@ -291,7 +273,7 @@ class MessageService:
                         else "Unknown"
                     ),
                     "energy_level": connection.current_energy_level,
-                    "stage": connection.stage,
+                    "stage": connection.connection_stage,
                 },
                 "pagination": {
                     "limit": limit,
@@ -342,7 +324,7 @@ class MessageService:
                     .filter(
                         Message.connection_id == connection.id,
                         Message.sender_id != user_id,
-                        Message.is_read is False,
+                        Message.is_read.is_(False),
                     )
                     .count()
                 )
@@ -357,10 +339,12 @@ class MessageService:
                     ),
                     total_messages=connection.total_messages_exchanged,
                     last_message_at=connection.last_message_at,
-                    last_message_content=(last_message.content if last_message else ""),
+                    last_message_content=(
+                        last_message.message_text if last_message else ""
+                    ),
                     unread_count=unread_count,
                     emotional_energy=connection.current_energy_level,
-                    conversation_stage=connection.stage,
+                    conversation_stage=connection.connection_stage,
                 )
 
                 conversations.append(
@@ -455,9 +439,9 @@ class MessageService:
                 .filter(
                     Message.connection_id == connection_id,
                     Message.sender_id != user_id,
-                    Message.is_read is False,
+                    Message.is_read.is_(False),
                 )
-                .update({"is_read": True, "read_at": datetime.utcnow()})
+                .update({"is_read": True})
             )
 
             db.commit()
@@ -529,12 +513,10 @@ class MessageService:
                 "sender": {
                     "id": sender.id,
                     "name": f"{sender.first_name} {sender.last_name}",
-                    "emotional_state": message.emotional_state,
                 },
-                "content": message.content,
-                "emotional_state": message.emotional_state,
-                "message_energy": message.message_energy,
-                "is_soul_revelation": message.is_soul_revelation,
+                "content": message.message_text,
+                "message_type": message.message_type,
+                "is_soul_revelation": message.message_type == "revelation",
                 "created_at": message.created_at.isoformat(),
             }
 


### PR DESCRIPTION
## Summary
- The \`/api/v1/messages/*\` flow (messages router + message_service) referenced columns that don't exist on the Message model: \`content\`, \`emotional_state\`, \`message_energy\`, \`is_soul_revelation\`, \`read_at\`. \`send_message\` would raise \`TypeError\` at \`Message(...)\` construction, making the endpoint non-functional end-to-end.
- Rewired all reads/writes to use the actual columns (\`message_text\`, \`message_type\`, \`is_read\`) so the API matches what the schema and migrations actually provide.
- Fixed three latent \`Message.is_read is False\` bugs (Python identity check instead of SQL filter) in message_service, messages router stats, and chat router conversations — unread counts were silently broken everywhere.

## Details
- \`message_service.py\`: rewrote \`send_message\`, \`get_conversation_messages\`, \`get_user_conversations\`, \`mark_messages_as_read\`, \`_deliver_message_realtime\` to use real fields. Also fixed \`connection.stage\` → \`connection.connection_stage\`.
- \`messages.py\` router: updated \`ConversationMessage\` response schema; stats now groups by \`message_type\` instead of non-existent \`emotional_state\`; removed unreachable \`_get_match_context\` method (indented inside \`search_messages\` as dead code); search now queries \`message_text\`.
- \`chat.py\` router: fixed \`is_read is False\` in conversations unread count.

## Test plan
- [ ] \`./start-app.sh\` brings up the stack without errors
- [ ] \`POST /api/v1/messages/send\` with a valid connection creates a Message row (previously threw at construction)
- [ ] \`GET /api/v1/messages/conversation/{id}\` returns messages and marks them read
- [ ] \`GET /api/v1/messages/statistics\` returns non-zero \`unread\` count when unread messages exist
- [ ] \`GET /api/v1/messages/search?query=...\` returns hits
- [ ] Angular chat view at \`/chat?connectionId=...\` still sends/receives via the \`chat.py\` router unaffected

## Notes
- \`tests/test_message_service.py\` is written against a fictional API (\`send_revelation_message\`, \`delete_message\`, \`get_typing_status\` etc. — none of these methods exist). It has never been green. Out of scope for this fix; worth a separate cleanup PR.